### PR TITLE
Allow for the latest versions to be built for metalium and ttnn

### DIFF
--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -2,7 +2,9 @@ name: Build and Deploy Sphinx Documentation
 
 on:
   workflow_dispatch:
-
+  push:
+    branches:
+      - main
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -1,6 +1,7 @@
 name: Build and Deploy Sphinx Documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -26,8 +26,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          wget https://github.com/tenstorrent/tt-metal/releases/download/v0.49.0/metal_libs-0.49.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-          pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.49.0+wormhole.b0-cp38-cp38-linux_x86_64.whl 
+
+          python3 -m venv --system-site-packages .docs-env
+          source .docs-env/bin/activate
       - name: Convert Installation.md to .rst in ttnn and tt-metallium docs
         run: |
           pandoc --from=markdown --to=rst --output=ttnn/ttnn/installing.rst ttnn/ttnn/installing.md

--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -2,9 +2,6 @@ name: Build and Deploy Sphinx Documentation
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/build_docs.py
+++ b/build_docs.py
@@ -11,16 +11,16 @@ def build_doc(project, version, additional_cmd):
         return
     
     subprocess.run(f"git checkout {project}_{version}", shell=True)
-    subprocess.run("git checkout dimitri/build_process_for_multiple_versions -- versions.yml", shell=True)
-    subprocess.run("git checkout dimitri/build_process_for_multiple_versions -- tt-metalium/conf.py", shell=True)
-    subprocess.run("git checkout dimitri/build_process_for_multiple_versions -- ttnn/conf.py", shell=True)
+    subprocess.run("git checkout main -- versions.yml", shell=True)
+    subprocess.run("git checkout main -- tt-metalium/conf.py", shell=True)
+    subprocess.run("git checkout main -- ttnn/conf.py", shell=True)
 
     version_no_v = version.replace("v", "")
 
     command = f"python3 -m venv .{version} && source .{version}/bin/activate\n"
     
     if additional_cmd:
-        command += additional_cmd
+        command += additional_cmd + "\n"
 
     command += f"cd {project} && make html\n"
     command += "deactivate\n"

--- a/build_docs.py
+++ b/build_docs.py
@@ -3,18 +3,30 @@ import subprocess
 import yaml
 
 
-def build_doc(project, version):
-    print(f"Building {project} {version}")
+def build_doc(project, version, additional_cmd):
+    print(f"Building {project} {version} with {additional_cmd}")
     os.environ[f"current_version"] = version
     if version == "latest":
         subprocess.run(f"cd {project} && make html", shell=True)
         return
     
     subprocess.run(f"git checkout {project}_{version}", shell=True)
-    subprocess.run("git checkout main -- conf.py", shell=True)
-    subprocess.run("git checkout main -- versions.yaml", shell=True)
+    subprocess.run("git checkout dimitri/build_process_for_multiple_versions -- versions.yml", shell=True)
+    subprocess.run("git checkout dimitri/build_process_for_multiple_versions -- tt-metalium/conf.py", shell=True)
+    subprocess.run("git checkout dimitri/build_process_for_multiple_versions -- ttnn/conf.py", shell=True)
 
-    subprocess.run(f"cd {project} && make html", shell=True)
+    version_no_v = version.replace("v", "")
+
+    command = f"python3 -m venv .{version} && source .{version}/bin/activate\n"
+    
+    if additional_cmd:
+        command += additional_cmd
+
+    command += f"cd {project} && make html\n"
+    command += "deactivate\n"
+    print("Full command to execute", command)
+    subprocess.run(command, shell=True)
+
 
 def move_dir(src, dst):
     subprocess.run(["mkdir", "-p", dst])
@@ -25,9 +37,14 @@ os.environ["homepage"] = "https://tenstorrent.github.io/"
 with open("versions.yml", "r") as yaml_file:
     subprocess.run("rm -rf output", shell=True)
     docs = yaml.safe_load(yaml_file)
-    for project, versions in docs.items():
-        for version in versions:
-            build_doc(project, version)
+
+    for project in docs.keys():
+        for version_desc in docs[project]["versions"].items():
+            version = version_desc[0]
+            additional_cmd = ""
+            if version_desc[1] and "additional_cmd" in version_desc[1]:
+                additional_cmd = version_desc[1]["additional_cmd"]
+            build_doc(project, version, additional_cmd)
             if project == "core" and version == "latest":
                 # This is a special case to populate the root folder and home page
                 move_dir(f"{project}/_build/html/", f"output/")

--- a/tt-metalium/conf.py
+++ b/tt-metalium/conf.py
@@ -88,7 +88,7 @@ with open("../versions.yml", "r") as yaml_file:
     versions = yaml.safe_load(yaml_file)["tt-metalium"]
 
 html_context = {
-    "versions": versions,
+    "versions": list(versions["versions"].keys()),
     "project_code": metal_sphinx_config.shortname,
     "current_version": os.environ.get("current_version"),
     "logo_link_url": os.environ.get("homepage")

--- a/ttnn/conf.py
+++ b/ttnn/conf.py
@@ -90,7 +90,7 @@ with open("../versions.yml", "r") as yaml_file:
     versions = yaml.safe_load(yaml_file)["ttnn"]
 
 html_context = {
-    "versions": versions,
+    "versions": list(versions["versions"].keys()),
     "project_code": metal_sphinx_config.shortname,
     "current_version": os.environ.get("current_version"),
     "logo_link_url": os.environ.get("homepage")

--- a/update_tags.py
+++ b/update_tags.py
@@ -7,7 +7,17 @@ version = sys.argv[2]
 with open("versions.yml", "r") as yaml_file:
     versions = yaml.safe_load(yaml_file)
 
-versions[project].append(version)
+version_structure = {version}
+
+if project in ["ttnn", "tt-metalium"]:
+    version_no_v = version.replace("v", "")
+    additional_cmd = \
+        f"wget https://github.com/tenstorrent/tt-metal/releases/download/{version}/metal_libs-{version_no_v}+wormhole.b0-cp38-cp38-linux_x86_64.whl\n"
+    additional_cmd += \
+        f"pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-{version_no_v}+wormhole.b0-cp38-cp38-linux_x86_64.whl"
+    version_structure = {version: {"additional_cmd": additional_cmd}}
+
+versions[project]["versions"].update(version_structure)
 
 with open("versions.yml", "w") as yaml_file:
     yaml.dump(versions, yaml_file)

--- a/versions.yml
+++ b/versions.yml
@@ -1,10 +1,37 @@
 core:
-- latest
+  versions:
+    latest:
 syseng:
-- latest
+  versions:
+    latest:
 pybuda:
-- latest
+  versions:
+    latest:
 tt-metalium:
-- latest
+  versions:
+    latest:
+      additional_cmd: |
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+    v0.51.0:
+      additional_cmd: |
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+    v0.50.0:
+      additional_cmd: |
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0/metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
 ttnn:
-- latest
+  versions:
+    latest:
+       additional_cmd: |
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+    v0.51.0:
+      additional_cmd: |
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+    v0.50.0:
+      additional_cmd: |
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0/metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl

--- a/versions.yml
+++ b/versions.yml
@@ -11,27 +11,19 @@ tt-metalium:
   versions:
     latest:
       additional_cmd: |
-        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-    v0.51.0:
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0/metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+    v0.52.0:
       additional_cmd: |
-        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-    v0.50.0:
-      additional_cmd: |
-        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0/metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0/metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
 ttnn:
   versions:
     latest:
        additional_cmd: |
-        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-    v0.51.0:
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0/metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+    v0.52.0:
       additional_cmd: |
-        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.51.0/metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.51.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-    v0.50.0:
-      additional_cmd: |
-        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.50.0/metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
-        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.50.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        wget https://github.com/tenstorrent/tt-metal/releases/download/v0.52.0/metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl
+        pip install --extra-index-url https://download.pytorch.org/whl/cpu metal_libs-0.52.0+wormhole.b0-cp38-cp38-linux_x86_64.whl


### PR DESCRIPTION
This PR allows for CI/CD job to create a new environment for installing additional requirements for the metal and ttnn and also additional commands such as downloading and installing versioned wheels.

This is important because some of the documentation in ttnn is introspected from Python files.