### PR TITLE
Workflows: moving the triggers around a little

### DIFF
--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -2,9 +2,8 @@ name: Build and Deploy Sphinx Documentation
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  workflow_call:
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-20.04

--- a/.github/workflows/trigger_pr-merged.yml
+++ b/.github/workflows/trigger_pr-merged.yml
@@ -1,0 +1,13 @@
+name: Trigger - PR merged to the Main branch
+run-name: Trigger - PR merged to the Main branch
+on:
+  workflow_dispatch:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/pages_deploy.yml
+    secrets: inherit

--- a/.github/workflows/trigger_push-main.yml
+++ b/.github/workflows/trigger_push-main.yml
@@ -1,0 +1,16 @@
+name: Trigger - Push to the Main branch
+run-name: Trigger - Push to the Main branch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  buildall:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Building"
+  buildd-and-deploy:
+      uses: ./.github/workflows/pages_deploy.yml
+      secrets: inherit


### PR DESCRIPTION
This should move the triggers around and a bit and allow for slightly more complex situation (read: PR merging) to trigger what we are expecting to run