### PR TITLE
Adding Bounty Program Terms

### DIFF
--- a/core/bounty_terms.md
+++ b/core/bounty_terms.md
@@ -1,0 +1,137 @@
+# TENSTORRENT BOUNTY PROGRAM TERMS AND CONDITIONS
+
+Please read these terms and conditions (these “**Terms**”), which form a legally binding contract between Tenstorrent AI ULC and its affiliates (“**Tenstorrent**,” “**us**,” or “**our**”) and qualifying individuals (“**Participant**,” “**you**,” or “**your**”) who wish to participate in Tenstorrent’s contribution program (the “**Program**”) and help improve our in-scope open-source projects by addressing issues, implementing new features, or resolving performance challenges (“**Contributions**”). Participants that submit Accepted Contributions shall be eligible to earn a payout (a “**Bounty**”), as determined solely in Tenstorrent’s discretion, in accordance with these Terms.
+
+These Terms include important clauses, including without limitation, instances where Participants may be liable to Tenstorrent, a class action waiver, and other limitations of your rights and remedies. Disputes will be adjudicated solely in the courts of the State of California. By participating in the Program, all Participants must agree to be bound by these Terms and comply with these Terms. If an individual does not wish to, or cannot comply with these Terms, they are ineligible for a Bounty Payout and must not participate in the Program.
+
+---
+
+## About the Program
+
+Tenstorrent offers this Program as an initiative for our community members that are helping us improve our open-source software. The Program is not a competition. No fees are payable or purchase is necessary to participate in the Program. All Program communication and updates will be shared via the relevant Tenstorrent open-source repository.
+
+This Program is a discretionary initiative. Tenstorrent, in our sole discretion, may modify these Terms at any time and may modify, restrict, suspend, terminate, or otherwise change any aspect of this Program, including the fulfillment of any Bounty Payouts at any time. If Tenstorrent changes these Terms, by continuing to participate in the Program, you are deemed to have accepted the changes.
+
+---
+## Participation Eligibility
+
+To be eligible to participate in the Program you must:
+
+* be the legal age of majority in your country and have the legal capacity to enter into, and be bound by, these Terms;
+* if you are participating in the Program as an entity, have the legal authority to accept these Terms on the applicable entity’s behalf (in which case “you” will mean the foregoing entity);
+* not be subject to legal obligations that prevent you from participating in the Program (for example, under your employment contract or ethical rules);
+* not be a sanctioned person or a citizen or resident of a sanctioned country under applicable law, including under U.S. embargo or sanctions;
+* not be in violation of any applicable laws or regulations when participating in the Program;
+* not ask for payment in exchange for issue details or dispute the applicability of the Program to you, including the amount of any proposed or actual payment or categorization of a Contribution; and
+* not be a current employee, vendor, contractor, or agent for Tenstorrent.
+
+You may be required to provide Tenstorrent with proof of compliance and eligibility in the form requested with regard to any of your obligations hereunder. Tenstorrent reserves the right to limit or refuse your eligibility to participate in the Program for any reason in its sole discretion, including but not limited to where your participation is prohibited by any applicable law. If Tenstorrent becomes aware of any violation of these Terms, Tenstorrent may elect to, among other things, (a) withhold, amend, or cancel the benefits of or payments under the Program or (b) require return of any payment made to you, including taking any action at law to obtain such payment.
+
+---
+## Scope of Contributions
+
+The Bounty will be applicable for Accepted Contributions in the following Tenstorrent repositories:
+* [tt-metal](https://github.com/tenstorrent/tt-metal)
+* [tt-mlir](https://github.com/tenstorrent/tt-mlir)
+* [tt-forge](https://github.com/tenstorrent/tt-forge)
+* [tt-tools-common](https://github.com/tenstorrent/tt-tools-common)
+* [tt-smi](https://github.com/tenstorrent/tt-smi)
+* [tt-topology](https://github.com/tenstorrent/tt-topology)
+* [luwen](https://github.com/tenstorrent/luwen)
+* [tt-flash](https://github.com/tenstorrent/tt-flash)
+* [tt-kmd](https://github.com/tenstorrent/tt-kmd)
+
+An **"Accepted Contribution"** refers to merged pull requests, to the aboe listed Tenstorrent repositories, that address an open GitHub issue which is tagged with both (1) “bounty” and (2) one of the categories listed in Exhibit A.
+
+---
+
+## Bounty Payment
+
+Subject to these Terms, you will receive payments based on the category of Contribution in accordance with Exhibit A. In order to receive a Bounty payment, you:
+
+* must not be in breach of these Terms;
+* must be assigned on GitHub to the ssue for which you are submitting a pull request, and your pull request must be submitted while you are still assigned to the issue (you have forfeited your right to any Bounty once the issue is re-assigned to another contributor). Tenstorrent reserves the right to re-assign any issue if the assigned contributor becomes unresponsive for over two (2) weeks or if the assigned contributor explicitly forfeits the assignment;
+* must release your Contributions under the license of the repository in which you are submitting a pull request;
+* provide additional information as may be required by us (such as payment information) and meet all requirements to receive such Bounty as may be required by applicable law and regulations. If you do not provide such additional information or meet such requirements, we may not provide payment; and
+* may not designate someone else to receive your Bounty payout.
+
+---
+
+## Your Obligations
+
+You shall:
+
+* only participate in the Program solely for the intended purpose of disclosing or resolving issues to Tenstorrent as described in these Terms and any related documentation;
+* participate in the Program for lawful purposes only and shall comply with all applicable laws and regulations; and
+* only access, disclose or modify your own user data and be solely responsible for the accuracy, completeness, appropriateness, and legality of any data or Contributions you upload or provide through your participation in the Program.
+
+You shall not:
+
+* attempt to gain access to another user’s account or data;
+* transmit any viruses or exploits through your participation in the Program, except for the sole purpose of discovery and submission of Contributions and subject to compliance with these Terms;
+* upload, input, access, store, distribute or any material that: (i) is unlawful, harmful, threatening, defamatory, obscene, infringing, harassing or racially or ethnically offensive; (ii) facilitates illegal activity; (iii) is otherwise illegal (including without limitation infringement of any third party intellectual property rights or any other rights); or (iv) causes damage or injury to any person or property; or
+* upload or input or otherwise disclose to Tenstorrent any information which you do not have the rights to or which you are under an existing contractual or other legal obligation to maintain in confidence.
+
+---
+
+## Intellectual Property Rights
+
+You acknowledge and agree that all your Contributions under the Program shall be released under the license of the repository in which you are submitting a pull request. You represent and warrant that your Contribution is your own work, that you haven’t used information owned by another person or entity, and that you have the legal right to submit the Contribution to Tenstorrent.
+
+Your rights with respect to our software, related documentation, and any updates, developments, or improvements thereto are governed by the license included in the applicable GitHub repository.
+
+---
+
+## Your Information
+
+You will provide us with all information as we may reasonably require for you to participate in the Program and, where relevant, receive a Bounty award. Tenstorrent shall only use the information you provide us to permit your participation in the Program and to tender Bounty payouts. Except for our obligations under applicable data protection laws with respect to our processing of any personal data you may provide us through your participation in Program, we disclaim all liability of any kind with respect to (i) any information, data or materials you upload or otherwise provide through your participation in the Program, (ii) third party information, (iii) any other material or services which may be accessed when participating in the Program, or (iv) for any fraud committed in connection with the Program.
+
+---
+
+## No Warranties
+
+TENSTORRENT MAKES NO WARRANTIES, EXPRESS OR IMPLIED, GUARANTEES OR CONDITIONS WITH RESPECT TO THE PROGRAM. YOU UNDERSTAND THAT YOUR PARTICIPATION IN THE PROGRAM IS AT YOUR OWN RISK. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAW, WE EXCLUDE ANY IMPLIED WARRANTIES IN CONNECTION WITH THE PROGRAM. YOU MAY HAVE CERTAIN RIGHTS UNDER YOUR LOCAL LAW. NOTHING IN THESE TERMS IS INTENDED TO AFFECT THOSE RIGHTS, IF THEY ARE APPLICABLE.
+
+---
+
+## Limitation of Liability and Disclaimer
+
+Should your participation in the Program be found to breach legal obligations you may have with other third parties or any other rights or in the event of a breach of these Terms, we may terminate your participation in the Program and may further deem you to be ineligible for a Bounty payment. You agree to defend, indemnify and hold harmless Tenstorrent and its respective officers, directors, employees, agents, licensors, and suppliers, from and against all claims, actions or demands, liabilities, and settlements, including, without limitation, reasonable legal and accounting fees, arising in connection with such breach.
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, (A) WE SHALL NOT BE LIABLE TO YOU FOR ANY DAMAGES, CLAIMS, EXPENSES OR OTHER COSTS (INCLUDING, WITHOUT LIMITATION, ATTORNEYS’ FEES) YOU SUFFER OR INCUR AS A RESULT OF THIRD-PARTY CLAIMS RELATING TO YOUR PARTICIPATION IN THE PROGRAM, (B) UNDER NO CIRCUMSTANCES WILL WE BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, PUNITIVE OR CONSEQUENTIAL DAMAGES, AND (C) OUR MAXIMUM AGGREGATE LIABILITY TO YOU ARISING OUT OF OR IN CONNECTION WITH THESE TERMS SHALL BE LIMITED TO $100, REGARDLESS OF THE CAUSE. WE DO NOT EXCLUDE OR LIMIT OUR LIABILITY FOR FRAUD OR FOR ANY OTHER LIABILITY WHICH CANNOT BE LIMITED OR EXCLUDED BY APPLICABLE LAW.   
+
+---
+
+## Issues
+
+If you encounter any issues with your participation in the Program, please reach out to us at bounties@tenstorrent.com.
+
+---
+
+## Applicability of these Terms
+
+These Terms shall apply for as long as you are participating in the Program pursuant to these Terms. Cancellation of the Program, termination of these Terms, or your explicit withdrawal from the Program shall not affect Tenstorrent’s rights and your obligations under these Terms prior to such cancellation or termination, which shall continue to apply, unless otherwise agreed in writing.
+
+---
+
+## Governing Law & Disputes
+
+These Terms shall be governed by and construed in accordance with the laws of the State of California and any federal laws applicable therein and shall be binding upon the parties hereto in California and worldwide. The parties consent to the exclusive jurisdiction of the courts of the State of California for any dispute arising out of this Agreement. Except where prohibited, as a condition of participating in this Program, each Participant agrees that between the parties, any and all disputes, claims, and causes of action arising out of or connected with this Program, or the Bounty Payout awarded must be resolved individually, without resort to any form of class action.
+
+---
+
+## General
+
+These Terms will be binding on and will inure to the benefit of the legal representatives, successors and assigns of the parties hereto. These Terms (and any policies referenced herein and incorporated by reference) constitute the entire agreement between you and us with respect to the subject matter hereof, and you have not relied upon any promises or representations by us with respect to the subject matter except as set forth herein. You may not assign these Terms or assign any rights or delegate any obligations hereunder, in whole or in part, whether voluntarily or by operation of law. The governing language of these Terms is English. A person who is not a party to these Terms has no rights to enforce, or to enjoy the benefit of, any term of these Terms.
+
+---
+
+## Exhibit A – Tenstorrent Bounty Rewards Chart
+
+| Category | Definition | Examples |  Payment Range  (US Dollars) |
+| :---- | :---- | :---- | :---- |
+| difficulty/warmup | Tasks suitable for first-time contributors. Straightforward and low complexity. | \- Minor bug fixes. \- Documentation improvements. \- Adding or fixing a test case. \- Basic logging updates. \- Updating a README or sample script. |  1 – 200 |
+| difficulty/easy | Tasks requiring basic familiarity with the repo and some understanding of the architecture. | \- Extending an existing feature. \- Updating API calls. \- Simple refactoring tasks. \- Adding a new test suite. |  201 – 500 |
+| difficulty/medium | Tasks requiring significant familiarity with the code base, architecture, or domain knowledge  | \- Implementing a new feature. \- Adding support for a new model. \- Debugging and fixing non-trivial performance issues. \- Integration of a library or external tool. |  501 – 1999 |
+| difficulty/hard | Complex tasks demanding deep architectural understanding and significant effort. | \- Major feature implementation. \- Core system redesign. \- Implementing a new kernel or low-level ops. \- Optimizing performance-critical code paths. |  2000 – 3000 |
+

--- a/core/index.rst
+++ b/core/index.rst
@@ -33,3 +33,10 @@ Tenstorrent
    :maxdepth: 2
 
    support/README
+
+.. toctree::
+   :hidden:
+   :caption: Legal
+   :maxdepth: 2
+
+   Bounty Program Terms <https://docs.tenstorrent.com/bounty_terms.html>


### PR DESCRIPTION
This centralizes the Bounty Program's terms to the docs site for easy finding / dealing with across the repositories