### PR TITLE
Use stable download URL for firmware

### DIFF
--- a/core/getting-started/README.md
+++ b/core/getting-started/README.md
@@ -115,7 +115,7 @@ To update Tenstorrent device firmware using TT-Flash, run these commands in the 
 
 ```{code-block} bash
 :substitutions:
-wget https://github.com/tenstorrent/tt-firmware/raw/main/fw_pack-{{ver_fw}}.fwbundle
+wget https://github.com/tenstorrent/tt-firmware/releases/download/v{{ver_fw}}/fw_pack-{{ver_fw}}.fwbundle
 tt-flash --fw-tar fw_pack-{{ver_fw}}.fwbundle
 ```
 


### PR DESCRIPTION
This PR uses the same stable URL that tt-installer uses to download the firmware bundle. This change ensures our docs do not break when a new release of `tt-firmware` is made