### PR TITLE
Update BMC Password

### DIFF
--- a/core/systems/quietbox/quietbox-bh/setup.md
+++ b/core/systems/quietbox/quietbox-bh/setup.md
@@ -126,7 +126,7 @@ This section describes an optional process to access the Base Management Control
 2.  On another computer connected to the same network, open a web browser.
 3.  When prompted, enter the following default credentials:
     *   **Username**: **admin**
-    *   **Password**: **ZTSI-00025**
+    *   **Password**: **ZTSI-00029**
 
 ---
 


### PR DESCRIPTION
From Marty:

"Hi All, just a heads up that apparently Swiftech updated the default password on the Blackhole QB BMC. It is now Username: admin Password: ZTSI-00029
We should update our online docs to reflect."