### PR TITLE
Add note about curl and jq dependencies

### DIFF
--- a/core/getting-started/README.md
+++ b/core/getting-started/README.md
@@ -41,7 +41,13 @@ If you update or reset your BIOS for any reason, you must reconfigure the PCIe A
 Tenstorrent recommends using the [tt-installer](https://github.com/tenstorrent/tt-installer/) script to install the Tenstorrent software stack. This script automates the setup process and is compatible with Ubuntu, Fedora, and Debian operating systems.
 
 ### **1\. Execute the installer**
-To begin the installation, execute the following command in your terminal:
+The installer has two dependencies, `curl` and `jq`. Install them using your system package manager. For example, on Ubuntu, run:
+
+```bash
+sudo apt update && sudo apt install -y curl jq
+```
+
+Now, to begin the installation, execute the following command in your terminal:
 
 ```bash
 /bin/bash -c "$(curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh)"


### PR DESCRIPTION
We get a lot of complaints from users about the script breaking due to missing jq. We updated tt-installer to show a clearer error message about this, but we should also put it in the docs.