### PR TITLE
Add the -- dummy to ensure proper argument parsing

### DIFF
--- a/core/getting-started/model-demos.md
+++ b/core/getting-started/model-demos.md
@@ -28,7 +28,7 @@ The model demos are packaged in a dedicated container. This keeps the demo envir
 Run the following command to add the models container to your existing Tenstorrent software installation.
 
 ```bash
-/bin/bash -c "$(curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh)" --no-install-kmd --no-install-hugepages --no-install-metalium-container --install-metalium-models-container --no-install-tt-flash --no-install-tt-topology --update-firmware="off" --reboot-option="never" --mode-non-interactive
+/bin/bash -c "$(curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh)" -- --no-install-kmd --no-install-hugepages --no-install-metalium-container --install-metalium-models-container --no-install-tt-flash --no-install-tt-topology --update-firmware="off" --reboot-option="never" --mode-non-interactive
 ```
 
 ## **Step 2: Starting the Container**


### PR DESCRIPTION
When running bash with -c, the first argument after the provided string is treated as @0, *not* an argument to the script. When running the existing command, the --no-install-kmd argument is ignored, and the first argument would always be ignored. To fix this, let's add -- as a dummy to become @0 so that all arguments are provided to the script as intended.