### PR TITLE
Remove grayskull/index from the index

### DIFF
--- a/core/aibs/index.rst
+++ b/core/aibs/index.rst
@@ -6,7 +6,6 @@ Add-In Boards / Cards
 
    blackhole/index
    wormhole/index
-   grayskull/index
    ack
    warp100
    compliance


### PR DESCRIPTION
[Issue#98](#98)

Deprecated item, removing product card from docs site landing page.