### PR TITLE
Update index.rst to remove t1000 and t7000

### DIFF
--- a/core/systems/index.rst
+++ b/core/systems/index.rst
@@ -7,5 +7,3 @@ Systems
    quietbox/quietbox-bh/index
    quietbox/quietbox-wh/index
    t3000/index
-   t1000/index
-   t7000/index


### PR DESCRIPTION
[Issue#98](https://github.com/tenstorrent/tenstorrent.github.io/issues/98)

Deprecated items, removing product cards from docs site landing page.