### PR TITLE
Revert "Remove grayskull/index from the index"

### DIFF
--- a/core/aibs/index.rst
+++ b/core/aibs/index.rst
@@ -6,6 +6,7 @@ Add-In Boards / Cards
 
    blackhole/index
    wormhole/index
+   grayskull/index
    ack
    warp100
    compliance


### PR DESCRIPTION
Reverts tenstorrent/tenstorrent.github.io#99. Removing from the index.rst file did not have the expected results. Correct changes included in: https://github.com/tenstorrent/tenstorrent.github.io/pull/101