### PR TITLE
Fixed reference to blockfp8 perf and removed fp8

### DIFF
--- a/core/aibs/blackhole/specifications.md
+++ b/core/aibs/blackhole/specifications.md
@@ -34,9 +34,8 @@ The **p100a** and **p150a** add-in board are designed for desktop workstations w
 | Memory                    | 28 GB GDDR6                 | 32 GB GDDR6                 | 32 GB GDDR6                 |
 | Memory Speed              | 16 GT/sec                   | 16 GT/sec                   | 16 GT/sec                   |
 | Memory Bandwidth          | 448 GB/sec                  | 512 GB/sec                  | 512 GB/sec                  |
-| TeraFLOPS (FP8)           | 664                         | 774                         | 774                         |
 | TeraFLOPS (FP16)          | 166                         | 194                         | 194                         |
-| TeraFLOPS (BLOCKFP8)      | 332                         | 387                         | 387                         |
+| TeraFLOPS (BLOCKFP8)      | 664                         | 774                         | 774                         |
 | TBP (Total Board Power)   | 300W                        | 300W                        | 300W                        |
 | External Power            | 1x 12+4-pin 12V-2x6         | 1x 12+4-pin 12V-2x6         | 1x 12+4-pin 12V-2x6         |
 | Power Supply Requirements | ATX 3.1 Certified or better | ATX 3.1 Certified or better | ATX 3.1 Certified or better |


### PR DESCRIPTION
Update the website as follows:

Blockfp8 flops should be 774 TFLOPS (what is currently for FP8)
Remove FP8 from the website
-- given that we’ve successfully converted (see below), 50 LLMs to blockfp8, blockfp4 so far, we don’t see the need for fp8 support in SW, and it would come at a performance penalty compared to blockfp’s due to additional quantization instructions
our website and docs should clearly state that blockfp8, blockfp4 are suprior to fp8 because they avoid quantization / de-quantization overheads

https://github.com/tenstorrent/tt-metal/issues/33035

This PR addresses the first part of the ticket.