### PR TITLE
Enable Tenstorrent Galaxy on DocSite, Add documentation templates for technical writer usage

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -29,7 +29,7 @@ Physical and software setup for Tenstorrent workstation and server solutions:
 
 - [**QuietBox Workstation**](./systems/quietbox/README.md)
 
-- [**Galaxy Wormhole 4U Server**](./galaxy4U/README.md)
+- [**Tenstorrent Galaxy**](./systems/tenstorrent-galaxy/index)
 
   
 

--- a/core/Resources/DOCUMENTATION_PROCESS.md
+++ b/core/Resources/DOCUMENTATION_PROCESS.md
@@ -1,0 +1,584 @@
+# Documentation Process Guide: Adding a New Systems Product
+
+This guide documents the complete process for adding a new product documentation section to the Tenstorrent documentation site, using the Tenstorrent Galaxy implementation as a reference example.
+
+## Table of Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Initial Setup](#initial-setup)
+3. [Creating the Product Structure](#creating-the-product-structure)
+4. [Adding Content with Myst Metadata](#adding-content-with-myst-metadata)
+5. [Adding PDF Downloads](#adding-pdf-downloads)
+6. [Building and Previewing](#building-and-previewing)
+7. [Git Workflow](#git-workflow)
+8. [Reference: File Structure](#reference-file-structure)
+
+---
+
+## Prerequisites
+
+- Python 3.x installed
+- Git access to the repository
+- Basic familiarity with Markdown and reStructuredText
+
+---
+
+## Initial Setup
+
+### 1. Activate Virtual Environment
+
+```bash
+cd "/path/to/tenstorrent.github.io"
+source .venv/bin/activate
+```
+
+If the virtual environment doesn't exist, create it:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### 2. Verify Dependencies
+
+Ensure all required packages are installed:
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## Creating the Product Structure
+
+### Step 1: Use the Product Template
+
+The product structure template is located at: `core/systems/_product_template/`
+
+**Template Structure:**
+```
+_product_template/
+├── index.rst          # Main index page with toctree
+├── specifications.md   # Technical specifications
+├── setup.md          # Setup/installation guide
+├── support.md        # Support and troubleshooting
+└── images/           # Directory for product images
+```
+
+**Note:** Document templates (How-To, Reference, Troubleshooting, Release Notes) are located in `core/Resources/` for reuse across all documentation.
+
+### Step 2: Create Your Product Directory
+
+1. **Copy the template** to create your new product directory:
+
+```bash
+cd core/systems
+cp -r _product_template your-product-name
+```
+
+2. **Rename files appropriately** (if needed):
+   - Keep the same structure: `index.rst`, `specifications.md`, etc.
+   - Use kebab-case for filenames (e.g., `installation-power-environmental.md`)
+
+### Step 3: Update the Main Index
+
+Edit `core/systems/index.rst` to add your product to the toctree:
+
+```rst
+Systems
+=======================================
+.. toctree::
+   :caption: Systems
+   :maxdepth: 2
+   
+   quietbox/quietbox-bh/index
+   quietbox/quietbox-wh/index
+   t3000/index
+   t1000/index
+   t7000/index
+   your-product-name/index    # Add your product here
+```
+
+### Step 4: Customize the Product Index
+
+Edit `core/systems/your-product-name/index.rst`:
+
+```rst
+Your Product Name
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+
+   specifications
+   setup
+   support
+```
+
+**Note:** Adjust the toctree entries to match your actual markdown files.
+
+---
+
+## Adding Content with Myst Metadata
+
+### Understanding Myst Metadata
+
+Myst metadata provides structured information for documentation indexing, search, and categorization. It's added as frontmatter at the top of each Markdown file.
+
+### Format
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Product Name, Alternative Name, Technology Name
+    technology-concepts: Concept1, Concept2, Concept3
+    document-type: Reference, Task-Based Guide, Explanation
+---
+
+# Your Document Title
+
+Your content here...
+```
+
+### Metadata Fields Explained
+
+1. **product-name**: Comma-separated list of product names, technology names, and related terms
+   - Example: `Tenstorrent Galaxy Server, Wormhole Networked AI Processor`
+
+2. **technology-concepts**: Comma-separated list of technical concepts, topics, or keywords
+   - Example: `Installation, Power Supply, Topology, Networking`
+
+3. **document-type**: Type of document (can be multiple, comma-separated)
+   - Common types:
+     - `Reference` - Technical specifications, reference material
+     - `Task-Based Guide` or `Task-Based Guide (How-To)` - Step-by-step instructions
+     - `Explanation` - Conceptual explanations
+     - `Prerequisites` - Requirements and prerequisites
+
+### Example: Complete Guide with Metadata
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Tenstorrent Galaxy Server, Wormhole Networked AI Processor
+    technology-concepts: Installation, Power Supply, Topology, Networking
+    document-type: Reference, Prerequisites
+---
+
+# Installation, Power, and Environmental Requirements
+
+This reference documentation provides professional installers and IT administrators with the critical physical, power, environmental, and networking specifications required to successfully prepare for and deploy the Tenstorrent Galaxy™ Server.
+
+## Physical Specifications and Packaging
+
+Content here...
+```
+
+### Reference Examples
+
+Look at existing guides for metadata patterns:
+
+- **QuietBox Setup** (`core/systems/quietbox/quietbox-bh/setup.md`):
+  - Product: `TT-QuietBox Blackhole™, Blackhole™ Networked AI Processor, Tensix core`
+  - Concepts: `PCIe, QSFP-DD, Installation, Setup, Electrostatic Discharge (ESD), Basic Input/Output System (BIOS)`
+  - Type: `Task-Based Guide (How-To)`
+
+- **Specifications** (`core/systems/quietbox/quietbox-bh/specifications.md`):
+  - Product: `TT-QuietBox, Blackhole`
+  - Concepts: `specifications, requirements, hardware`
+  - Type: `Reference`
+
+---
+
+## Adding PDF Downloads
+
+### Step 1: Add PDF File
+
+Place your PDF file in the product directory:
+
+```bash
+cp your-guide.pdf core/systems/your-product-name/your_product_user_guide.pdf
+```
+
+**Naming convention:** Use lowercase with underscores (e.g., `tenstorrent_galaxy_user_guide.pdf`)
+
+### Step 2: Add Download Link to Index
+
+Edit `core/systems/your-product-name/index.rst`:
+
+```rst
+Your Product Name
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+
+   specifications
+   setup
+   support
+
+Download User Guide
+--------------------
+
+.. raw:: html
+
+   <a href="your_product_user_guide.pdf" target="_blank" download>Your Product User Guide</a>
+```
+
+**Key points:**
+- Use `.. raw:: html` directive to include HTML
+- `target="_blank"` opens in a new tab
+- `download` attribute triggers download behavior
+- Filename must match the PDF file in the directory
+
+### Step 3: Ensure PDF is Copied to Build Output
+
+**Important:** Sphinx doesn't automatically copy PDF files. After building, manually copy:
+
+```bash
+cd core
+cp systems/your-product-name/your_product_user_guide.pdf _build/html/systems/your-product-name/
+```
+
+**For production:** Consider adding a post-build step to the Makefile to automate this.
+
+---
+
+## Building and Previewing
+
+### Standard Build
+
+```bash
+cd core
+make html
+```
+
+### Clean Build (removes cached files)
+
+```bash
+cd core
+rm -rf _build
+make html
+```
+
+### Open in Browser
+
+```bash
+# Open main index
+open _build/html/index.html
+
+# Open specific product page
+open _build/html/systems/your-product-name/index.html
+```
+
+### Build Output Location
+
+All HTML files are generated in: `core/_build/html/`
+
+---
+
+## Git Workflow
+
+### 1. Create a Feature Branch
+
+```bash
+git checkout -b feature/your-product-docs
+```
+
+### 2. Stage Changes
+
+```bash
+git add -A
+```
+
+### 3. Commit with Descriptive Message
+
+```bash
+git commit -m "Add [Product Name] documentation section
+
+- Add Technical Specifications guide
+- Add Installation and Setup guide
+- Add [other guides]
+- Add PDF user guide download functionality
+- Update systems index to reference new section"
+```
+
+### 4. Push to Remote
+
+```bash
+git push -u origin feature/your-product-docs
+```
+
+### 5. Create Pull Request
+
+Either via GitHub web interface or CLI:
+
+```bash
+gh pr create --base main --head feature/your-product-docs \
+  --title "Add [Product Name] Documentation Section" \
+  --body "Adds comprehensive documentation for [Product Name] including specifications, installation requirements, and setup guides."
+```
+
+---
+
+## Reference: File Structure
+
+### Complete Product Directory Structure
+
+```
+core/systems/your-product-name/
+├── index.rst                          # Main index with toctree and download link
+├── specifications.md                  # Technical specifications (with myst metadata)
+├── installation-power-environmental.md  # Installation guide (with myst metadata)
+├── software-setup-configuration.md     # Software setup guide (with myst metadata)
+├── cabling-configuration.md           # Cabling guide (with myst metadata)
+├── per-tray-isolation-release.md      # Hardware maintenance guide (with myst metadata)
+├── compliance-safety-notices.md       # Compliance guide (with myst metadata)
+├── your_product_user_guide.pdf        # PDF user guide
+├── images/                            # Product images (optional)
+│   └── .gitkeep
+└── README_PDF.md                      # Instructions for PDF (optional helper file)
+```
+
+### Index.rst Template
+
+```rst
+Product Name
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+
+   specifications
+   installation-power-environmental
+   software-setup-configuration
+   cabling-configuration
+   per-tray-isolation-release
+   compliance-safety-notices
+
+Download User Guide
+--------------------
+
+.. raw:: html
+
+   <a href="your_product_user_guide.pdf" target="_blank" download>Product User Guide</a>
+```
+
+### Markdown File Template
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Product Name, Alternative Name
+    technology-concepts: Concept1, Concept2, Concept3
+    document-type: Reference, Task-Based Guide
+---
+
+# Document Title
+
+Introduction paragraph explaining what this document provides and who it's for.
+
+## Section 1
+
+Content here...
+
+### Subsection 1.1
+
+More content...
+
+## Section 2
+
+Content here...
+
+:::{important}
+Important information that users should know.
+:::
+
+:::{warning}
+Warning about potential issues or safety concerns.
+:::
+```
+
+---
+
+## Common Markdown Features
+
+### Admonitions (Callout Boxes)
+
+```markdown
+:::{note}
+This is a note.
+:::
+
+:::{important}
+This is important information.
+:::
+
+:::{warning}
+This is a warning.
+:::
+
+:::{danger}
+This is a danger warning.
+:::
+```
+
+### Tables
+
+```markdown
+| Column 1 | Column 2 | Column 3 |
+| :--- | :--- | :--- |
+| Row 1 Col 1 | Row 1 Col 2 | Row 1 Col 3 |
+| Row 2 Col 1 | Row 2 Col 2 | Row 2 Col 3 |
+```
+
+### Links
+
+```markdown
+[Link Text](https://example.com)
+[Internal Link](specifications.md)
+[External Link](https://github.com/tenstorrent/tt-metal)
+```
+
+### Code Blocks
+
+````markdown
+```bash
+command --option value
+```
+
+```python
+def example():
+    return "code"
+```
+````
+
+---
+
+## Troubleshooting
+
+### PDF Not Appearing After Build
+
+**Problem:** PDF download link doesn't work after rebuilding.
+
+**Solution:** Sphinx doesn't automatically copy PDFs. Manually copy after each build:
+
+```bash
+cp core/systems/your-product-name/your_product_user_guide.pdf \
+   core/_build/html/systems/your-product-name/
+```
+
+### Build Warnings About Missing Files
+
+**Problem:** Warnings like "toctree contains reference to nonexisting document"
+
+**Solution:** 
+- Check that all files referenced in `index.rst` actually exist
+- Ensure filenames match exactly (case-sensitive)
+- Remove references to files you don't need
+
+### Old Content Still Showing
+
+**Problem:** Browser shows old content even after rebuilding.
+
+**Solution:**
+1. Do a clean build: `rm -rf _build && make html`
+2. Hard refresh browser: `Cmd+Shift+R` (Mac) or `Ctrl+Shift+R` (Windows/Linux)
+3. Clear browser cache
+
+### Metadata Not Working
+
+**Problem:** Myst metadata not being recognized.
+
+**Solution:**
+- Ensure frontmatter is at the very top of the file (no content before `---`)
+- Check YAML syntax (proper indentation, no tabs)
+- Verify closing `---` is present
+- Check for special characters that might break YAML parsing
+
+---
+
+## Best Practices
+
+1. **Naming Conventions:**
+   - Use kebab-case for filenames: `installation-power-environmental.md`
+   - Use descriptive, clear names
+   - Keep names consistent across related files
+
+2. **Metadata:**
+   - Be comprehensive with product names (include all variations)
+   - Include relevant technology concepts for better searchability
+   - Choose appropriate document types
+
+3. **Content Organization:**
+   - Start with an introduction explaining the document's purpose
+   - Use clear section headings
+   - Include tables for specifications
+   - Use admonitions for important information
+
+4. **Git Workflow:**
+   - Create feature branches for new products
+   - Write descriptive commit messages
+   - Test builds before pushing
+   - Create PRs for team review
+
+5. **Testing:**
+   - Always rebuild and preview locally before committing
+   - Test all links (internal and external)
+   - Verify PDF downloads work
+   - Check that all images load correctly
+
+---
+
+## Quick Reference Checklist
+
+When adding a new product documentation section:
+
+- [ ] Create product directory from template
+- [ ] Update `core/systems/index.rst` to include new product
+- [ ] Customize `index.rst` in product directory
+- [ ] Create markdown files with myst metadata
+- [ ] Add content to each guide
+- [ ] Add PDF file (if applicable) and download link
+- [ ] Build docs: `cd core && make html`
+- [ ] Copy PDF to build output (if applicable)
+- [ ] Preview in browser
+- [ ] Test all links and downloads
+- [ ] Commit changes to feature branch
+- [ ] Push to remote
+- [ ] Create pull request
+
+---
+
+## Additional Resources
+
+- **Sphinx Documentation:** https://www.sphinx-doc.org/
+- **MyST Markdown:** https://mystmd.org/
+- **reStructuredText Primer:** https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
+
+---
+
+## Example: Tenstorrent Galaxy Implementation
+
+The Tenstorrent Galaxy documentation serves as a complete reference implementation:
+
+- **Location:** `core/systems/tenstorrent-galaxy/`
+- **Guides Created:**
+  1. Technical Specifications
+  2. Installation, Power, and Environmental Requirements
+  3. Software Setup and Configuration
+  4. Cabling Configuration (placeholder)
+  5. Per-Tray Isolation Release (placeholder)
+  6. Compliance and Safety Notices (placeholder)
+- **Features:**
+  - PDF download functionality
+  - Complete myst metadata on all guides
+  - Proper toctree structure
+  - Clean navigation
+
+Review this implementation for a complete working example of the process documented above.
+

--- a/core/Resources/HOW_TO_GUIDE_TEMPLATE.md
+++ b/core/Resources/HOW_TO_GUIDE_TEMPLATE.md
@@ -1,0 +1,532 @@
+# Task-Based Guide (How-To) Template
+
+This template provides a structured rubric for creating Task-Based Guides (How-To's). Use this template as a starting point for all step-by-step instructional documentation.
+
+---
+
+## Template Structure
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Product Name, Alternative Name, Technology Name
+    technology-concepts: Concept1, Concept2, Concept3, Concept4
+    document-type: Task-Based Guide (How-To)
+---
+
+# [Gerund Verb] the [Product/Feature Name]
+
+[One-to-three sentence summary that answers:]
+- Who is this for?
+- What will they learn or be able to do?
+
+Example: "This guide provides system administrators, hardware engineers, and users responsible for the initial setup of Tenstorrent hardware with step-by-step instructions. You will learn to safely unbox a TT-QuietBox Blackhole™ workstation, connect all required hardware components, and install the recommended operating system."
+
+## Before You Begin
+
+[Context-setting paragraph that prepares the user for the task. Include:]
+- Physical space requirements
+- Safety considerations
+- Time estimates (if applicable)
+- Any preliminary steps or decisions needed
+
+### Prerequisites
+
+[Clear list of what the user must have or know before starting:]
+
+**Required Knowledge:**
+* Basic understanding of [topic/concept]
+* Familiarity with [tool/system]
+
+**Required Hardware:**
+* [Hardware item 1]
+* [Hardware item 2]
+
+**Required Software:**
+* [Software/version]
+* [Tool/version]
+
+**Required Access:**
+* [Permissions, accounts, or access needed]
+
+### Required Tools and Equipment
+
+[Physical tools, software tools, or resources needed:]
+
+* [Tool 1] - [Purpose]
+* [Tool 2] - [Purpose]
+
+### Safety Warnings
+
+[Include any safety considerations. Link to detailed safety information if available.]
+
+:::{warning}
+[Critical safety information that must not be missed. Be specific about risks and consequences.]
+:::
+
+[Optional: Link to detailed safety documentation]
+For detailed safety information, see [Safety Warnings](specifications.md#safety-warnings).
+
+---
+
+## Step 1: [Descriptive Action Name]
+
+[Brief introduction to what this step accomplishes.]
+
+Follow these steps to [accomplish the goal]:
+
+1. **Action description.** [Detailed instruction with specific details.]
+   
+   [Optional: Include image with descriptive alt text]
+   ![](image_filename.png)
+   
+   [Optional: Include note or tip]
+   :::{note}
+   [Supplementary information that may be helpful.]
+   :::
+
+2. **Action description.** [Detailed instruction.]
+   
+   [Optional: Include code block for commands]
+   ```bash
+   $ command --option value
+   ```
+   
+   [Expected output or result]
+   ```
+   Expected output here
+   ```
+
+3. **Action description.** [Continue with numbered steps.]
+
+[Optional: Verification step]
+**Verify the result:** [How to confirm this step completed successfully]
+
+---
+
+## Step 2: [Descriptive Action Name]
+
+[Brief introduction to what this step accomplishes.]
+
+[Continue with numbered steps following the same pattern as Step 1.]
+
+---
+
+## Step 3: [Descriptive Action Name]
+
+[Continue pattern for all steps.]
+
+---
+
+## Verification and Testing
+
+[Section for verifying the entire process completed successfully:]
+
+1. **Verification step 1:** [How to verify]
+   ```bash
+   $ verification-command
+   ```
+   
+   [Expected output]
+   ```
+   Expected verification output
+   ```
+
+2. **Verification step 2:** [Additional verification]
+
+:::{important}
+[Critical information about what success looks like or what to do if verification fails.]
+:::
+
+---
+
+## Troubleshooting
+
+[Common issues and solutions:]
+
+### Issue: [Problem Description]
+
+**Symptoms:**
+* [Symptom 1]
+* [Symptom 2]
+
+**Solution:**
+[Step-by-step resolution]
+
+**If this does not resolve the issue:**
+[Link to support or additional resources]
+
+---
+
+## Next Steps
+
+[What the user should do after completing this guide:]
+
+* [Next action or guide to follow]
+* [Related documentation]
+* [Additional resources]
+
+---
+
+## Need Additional Support?
+
+If you encounter any issues, or have a question that is not covered in the documentation, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
+
+---
+
+## Related Documentation
+
+* [Related guide 1](link-to-guide.md)
+* [Related guide 2](link-to-guide.md)
+* [Reference documentation](link-to-reference.md)
+```
+
+---
+
+## Quality Checklist
+
+Use this checklist to ensure your guide meets documentation standards:
+
+### Document Structure
+
+- [ ] **Title:** Starts with a gerund (verb ending in "-ing")
+  - ✅ Correct: "Installing the Tenstorrent Software Stack"
+  - ❌ Incorrect: "Install the Tenstorrent Software Stack"
+
+- [ ] **Summary:** One-to-three sentences answering:
+  - [ ] Who is this for?
+  - [ ] What will they learn or be able to do?
+
+- [ ] **Metadata:** Complete myst frontmatter with:
+  - [ ] Product names (comma-separated, all variations)
+  - [ ] Technology concepts (comma-separated, relevant keywords)
+  - [ ] Document type: "Task-Based Guide (How-To)"
+
+### Content Quality
+
+- [ ] **Voice:** Writing is:
+  - [ ] Honest (transparent about complexity and limitations)
+  - [ ] Sharp (precise, quantitative data)
+  - [ ] Human (active voice, direct address)
+  - [ ] Concise (no unnecessary words)
+
+- [ ] **Prohibited Language:** Avoided:
+  - [ ] "Dynamic," "Ultimate," "Exceptional"
+  - [ ] "Leading Edge," "Cutting Edge"
+  - [ ] "Powerful," "High Impact"
+  - [ ] "Revolution," "Disrupt"
+  - [ ] "Limitless," "Maximum"
+
+- [ ] **Grammar:**
+  - [ ] No contractions (use "do not" not "don't")
+  - [ ] Acronyms spelled out on first use with acronym in parentheses
+  - [ ] Product names capitalized correctly with trademark symbols (™)
+
+### Formatting
+
+- [ ] **Headings:** Sequential hierarchy (H2 → H3 → H4, no skipping)
+- [ ] **Lists:** 
+  - [ ] Numbered lists for sequential steps
+  - [ ] Bulleted lists for unordered items
+- [ ] **Emphasis:**
+  - [ ] **Bold** for UI elements and user input
+  - [ ] *Italics* for conceptual emphasis and file paths
+- [ ] **Code:**
+  - [ ] Code blocks with language specified
+  - [ ] Commands prefixed with `$` prompt
+  - [ ] Inline code with backticks for technical terms
+- [ ] **Admonitions:** Used appropriately:
+  - [ ] `:::{note}` for supplementary information
+  - [ ] `:::{important}` for critical information
+  - [ ] `:::{warning}` for safety concerns or risks
+  - [ ] `:::{admonition} Important :class: danger` for critical failures
+
+### Media
+
+- [ ] **Images:**
+  - [ ] Only when essential (not for text or code)
+  - [ ] Descriptive alt text provided
+  - [ ] Consistent OS/theme if screenshots
+  - [ ] Annotations use brand colors (Black #202020, Tens Purple #7C68FA)
+
+- [ ] **Tables:**
+  - [ ] Headers with Black background (#202020), White text (#FFFFFF)
+  - [ ] Clear, structured data
+
+### Accessibility
+
+- [ ] **Alt Text:** Every meaningful image has descriptive alt text
+- [ ] **Links:** Link text clearly describes destination (not "click here")
+- [ ] **Color:** Not used as sole information carrier (accompanied by text/icons)
+
+---
+
+## Required Sections Reference
+
+Every Task-Based Guide must include:
+
+1. **Title** (Gerund form)
+2. **Summary** (Who + What they'll learn)
+3. **Before You Begin** (Context and preparation)
+4. **Prerequisites** (Knowledge, hardware, software, access)
+5. **Required Tools and Equipment**
+6. **Safety Warnings** (if applicable)
+7. **Step-by-Step Instructions** (Numbered, clear actions)
+8. **Verification** (How to confirm success)
+9. **Troubleshooting** (Common issues and solutions)
+10. **Next Steps** (What to do after completion)
+11. **Support Information** (How to get help)
+
+---
+
+## Example: Complete Guide Structure
+
+Here's how a complete guide should look:
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: TT-QuietBox Blackhole™, Blackhole™ Networked AI Processor, Tensix core
+    technology-concepts: PCIe, QSFP-DD, Installation, Setup, Electrostatic Discharge (ESD), Basic Input/Output System (BIOS)
+    document-type: Task-Based Guide (How-To)
+---
+
+# Receiving, Unboxing, and Setup
+
+This guide provides system administrators, hardware engineers, and users responsible for the initial setup of Tenstorrent hardware with step-by-step instructions. You will learn to safely unbox a TT-QuietBox Blackhole™ workstation, connect all required hardware components, and install the recommended operating system.
+
+## Before You Begin
+
+Before you begin, choose a clear, stable, and spacious area for the TT-QuietBox Blackhole™ workstation. The system ships in a palletized wooden crate. Ensure you have at least two people and enough room for them to maneuver comfortably and safely around the crate and system.
+
+### Prerequisites
+
+**Required Knowledge:**
+* Basic understanding of computer hardware assembly
+* Familiarity with Linux command line (for verification steps)
+
+**Required Hardware:**
+* Keyboard (user-provided)
+* Mouse (user-provided)
+* Monitor (user-provided)
+* Ethernet cable, Cat 6 or better (user-provided)
+
+**Required Software:**
+* None (operating system pre-installed)
+
+### Required Tools and Equipment
+
+For unboxing, you will need the following tools:
+
+* Phillips head screwdriver
+* Scissors or similar cutting tool
+
+### Safety Warnings
+
+:::{warning}
+The fully palletized and crated shipment weighs approximately 134 lbs (61 kg), and the workstation itself weighs approximately 80 lbs (36 kg). Unboxing and lifting require at least two people for safe maneuverability.
+
+Do not proceed with unboxing or installation if you suspect shipping damage to the system. Contact Tenstorrent support by [raising a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1)
+:::
+
+For detailed safety information, see [Safety Warnings](specifications.md#safety-warnings).
+
+---
+
+## Step 1: Unboxing the Workstation
+
+Follow these steps to unbox your TT-QuietBox Blackhole™ workstation:
+
+1. **Position the crate.** Position the crate in your prepared unboxing area, ensuring ample space for two people to work around it.
+   
+   ![](qb_setup_1.jpg)
+
+2. **Remove plastic wrap.** Remove the outer plastic wrap and cut the two lifting straps looped around the crate.
+   
+   ![](qb_setup_2.jpg)
+
+[Continue with remaining steps...]
+
+---
+
+## Verification and Testing
+
+Verify that all four accelerators are recognized by the system:
+
+```bash
+$ sudo update-pciids
+$ lspci -d 1e52:
+```
+
+You should see an output listing four recognized accelerators:
+```
+01:00.0 Processing accelerators: Tenstorrent Inc Blackhole
+41:00.0 Processing accelerators: Tenstorrent Inc Blackhole
+42:00.0 Processing accelerators: Tenstorrent Inc Blackhole
+c1:00.0 Processing accelerators: Tenstorrent Inc Blackhole
+```
+
+:::{important}
+If you do not see all four accelerators listed, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
+:::
+
+---
+
+## Troubleshooting
+
+### Issue: System Does Not Power On
+
+**Symptoms:**
+* Power button does not respond
+* No LED indicators visible
+* No fan noise
+
+**Solution:**
+1. Verify the power supply switch on the rear panel is set to **ON**.
+2. Check that the power cable is securely connected to both the workstation and the power outlet.
+3. Test the power outlet with another device to confirm it is functioning.
+
+**If this does not resolve the issue:**
+[Raise a support request](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) with details about your power supply configuration.
+
+---
+
+## Next Steps
+
+After completing this setup guide:
+
+* [Installing the Tenstorrent Software Stack](../../../getting-started/README.md)
+* [Running Model Demos](../../../getting-started/model-demos.md)
+* Review the [Technical Specifications](specifications.md) for detailed system information
+
+---
+
+## Need Additional Support?
+
+If you encounter any issues, or have a question that is not covered in the documentation, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
+
+---
+
+## Related Documentation
+
+* [Technical Specifications](specifications.md)
+* [Troubleshooting Common Hardware Issues](../common/support.md)
+* [Tenstorrent Software Stack Installation](../../../getting-started/README.md)
+```
+
+---
+
+## Writing Tips
+
+### Step Descriptions
+
+**Do:**
+* Start each step with a bold action verb: "**Connect** the power cable..."
+* Be specific: "Connect the C13 power cable to the rear panel power input port"
+* Include verification: "You should hear an audible click when the cable is properly seated"
+
+**Do Not:**
+* Use vague language: "Set up the system" (too vague)
+* Assume knowledge: "Connect it like normal" (what is "normal"?)
+* Skip verification: Always tell users how to confirm a step worked
+
+### Code Blocks
+
+**Format:**
+```bash
+$ command --option value
+```
+
+**Include:**
+* Expected output when relevant
+* Error messages users might see
+* Explanations of what each command does
+
+### Images
+
+**When to Use:**
+* Showing physical connections or hardware locations
+* Demonstrating UI elements that are hard to describe
+* Illustrating complex topologies or relationships
+
+**When Not to Use:**
+* Screenshots of terminal output (use code blocks instead)
+* Images of text that could be written
+* Decorative images without purpose
+
+### Admonitions
+
+**Use Warning for:**
+* Safety hazards
+* Potential data loss
+* Irreversible actions
+* System damage risks
+
+**Use Important for:**
+* Critical information that must not be missed
+* Success criteria
+* Required follow-up actions
+
+**Use Note for:**
+* Helpful tips
+* Optional information
+* Context or background
+
+---
+
+## Quality Assurance
+
+Before submitting your guide, verify:
+
+1. **Completeness:**
+   - [ ] All required sections present
+   - [ ] Every step has clear instructions
+   - [ ] Verification steps included
+   - [ ] Troubleshooting covers common issues
+
+2. **Accuracy:**
+   - [ ] All commands tested and working
+   - [ ] File paths verified
+   - [ ] Links tested and functional
+   - [ ] Product names and versions correct
+
+3. **Clarity:**
+   - [ ] No ambiguous instructions
+   - [ ] Technical terms defined on first use
+   - [ ] Prerequisites clearly stated
+   - [ ] Expected outcomes described
+
+4. **Writing Standards:**
+   - [ ] Clear, concise language
+   - [ ] Proper capitalization and trademarks
+   - [ ] No contractions
+   - [ ] Active voice throughout
+
+5. **Accessibility:**
+   - [ ] All images have alt text
+   - [ ] Links have descriptive text
+   - [ ] Color not used as sole information carrier
+   - [ ] Tables properly formatted
+
+---
+
+## Additional Resources
+
+* [Sphinx Documentation](https://www.sphinx-doc.org/)
+* [MyST Markdown Guide](https://mystmd.org/)
+
+---
+
+## Template Usage Notes
+
+1. **Copy this template** to create your guide
+2. **Replace all bracketed placeholders** with actual content
+3. **Remove sections** that do not apply to your specific guide
+4. **Add sections** as needed for your specific use case
+5. **Follow the checklist** to ensure quality standards
+6. **Test all commands and links** before finalizing
+
+Remember: This template is a starting point. Adapt it to fit your specific documentation needs while maintaining quality and consistency standards.
+

--- a/core/Resources/REFERENCE_DOC_TEMPLATE.md
+++ b/core/Resources/REFERENCE_DOC_TEMPLATE.md
@@ -1,0 +1,343 @@
+# Reference Documentation Template
+
+This template provides a structured rubric for creating Reference Documentation. Use this template as a starting point for all technical specifications, API references, and factual documentation.
+
+---
+
+## Template Structure
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Product Name, Alternative Name, Technology Name
+    technology-concepts: Concept1, Concept2, Concept3, Concept4
+    document-type: Reference
+---
+
+# [Precise Title Including Product/Tool Name and Version]
+
+[One-to-three sentence summary that answers:]
+- Who is this for?
+- What information does it provide?
+
+Example: "This document provides system administrators and engineers with detailed technical specifications for the TT-QuietBox™ Blackhole™ (TW-04002) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements."
+
+## Package Contents
+
+[If applicable, list what is included with the product:]
+
+The [Product Name] package includes the following items:
+
+* [Item 1]
+* [Item 2]
+* [Item 3]
+
+:::{warning}
+[Any important warnings about package contents, shipping, or handling]
+:::
+
+For assembly instructions, refer to the [Setup Guide](./setup.md). If you encounter issues, refer to the [Troubleshooting Guide](./support.md).
+
+## System Specifications
+
+[Use tables for structured specification data:]
+
+| Specification | Details |
+| :--- | :--- |
+| **Specification Name** | Specification value |
+| **Another Spec** | Another value |
+
+## [Category 1: e.g., Processing and Memory]
+
+[Organize specifications by category:]
+
+| Specification | Description |
+| :--- | :--- |
+| **Spec Name** | Detailed description |
+| **Another Spec** | Another description |
+
+## [Category 2: e.g., Storage]
+
+[Continue with categorized specifications:]
+
+| Specification | Description |
+| :--- | :--- |
+| **Spec Name** | Description |
+
+## [Category 3: e.g., Connectivity]
+
+### [Subcategory: e.g., Internal Connectivity]
+
+| Specification | Description |
+| :--- | :--- |
+| **Spec Name** | Description |
+
+### [Subcategory: e.g., External Networking]
+
+| Specification | Description |
+| :--- | :--- |
+| **Spec Name** | Description |
+
+## [Category 4: e.g., Input/Output (I/O)]
+
+### [Subcategory: e.g., Front I/O]
+
+| Specification | Description |
+| :--- | :--- |
+| **Spec Name** | Description |
+
+### [Subcategory: e.g., Rear I/O]
+
+| Specification | Description |
+| :--- | :--- |
+| **Spec Name** | Description |
+
+## Environment
+
+[Environmental specifications if applicable:]
+
+| Environmental Specification | Operating Condition | Storage Condition |
+| :--- | :--- | :--- |
+| **Temperature** | [Range] | [Range] |
+| **Relative Humidity** | [Range] | [Range] |
+
+## Safety Warnings
+
+[Include safety information:]
+
+:::{warning}
+[Critical safety warning with specific details]
+:::
+
+[Additional safety information or links to detailed safety documentation]
+
+## Compliance and Certifications
+
+[If applicable:]
+
+* [Certification 1]
+* [Certification 2]
+* [Compliance standard]
+
+---
+
+## Related Documentation
+
+* [Setup Guide](./setup.md)
+* [Troubleshooting Guide](./support.md)
+* [Additional Reference](link-to-reference.md)
+```
+
+---
+
+## Quality Checklist
+
+Use this checklist to ensure your reference documentation meets standards:
+
+### Document Structure
+
+- [ ] **Title:** Precise and includes product/tool name and version (if applicable)
+  - ✅ Correct: "TT-Buda™ v1.2 API Reference"
+  - ✅ Correct: "Technical Specifications"
+  - ❌ Incorrect: "Specs" (too vague)
+
+- [ ] **Summary:** One-to-three sentences answering:
+  - [ ] Who is this for?
+  - [ ] What information does it provide?
+
+- [ ] **Metadata:** Complete myst frontmatter with:
+  - [ ] Product names (comma-separated, all variations)
+  - [ ] Technology concepts (comma-separated, relevant keywords)
+  - [ ] Document type: "Reference"
+
+### Content Quality
+
+- [ ] **Accuracy:** All specifications are:
+  - [ ] Factually correct
+  - [ ] Up-to-date
+  - [ ] Verified against actual hardware/software
+  - [ ] Include units of measurement where applicable
+
+- [ ] **Completeness:**
+  - [ ] All major categories covered
+  - [ ] No critical information missing
+  - [ ] Cross-references to related documentation included
+
+- [ ] **Organization:**
+  - [ ] Logical grouping of specifications
+  - [ ] Clear hierarchy (categories and subcategories)
+  - [ ] Consistent formatting throughout
+
+### Formatting
+
+- [ ] **Tables:**
+  - [ ] Headers clearly labeled
+  - [ ] Consistent column alignment
+  - [ ] All data properly formatted
+  - [ ] Units included where applicable
+
+- [ ] **Headings:** Sequential hierarchy (H2 → H3 → H4, no skipping)
+- [ ] **Lists:** Bulleted lists for package contents and unordered items
+- [ ] **Admonitions:** Used appropriately for warnings and important information
+
+### Reference Standards
+
+- [ ] **Precision:** Use exact values, not approximations
+- [ ] **Units:** Include units for all measurements
+- [ ] **Versioning:** Include version numbers for software/API references
+- [ ] **Links:** All cross-references to other documentation are valid
+
+---
+
+## Required Sections Reference
+
+Every Reference Document should include:
+
+1. **Title** (Precise, includes product/tool name)
+2. **Summary** (Who + What information provided)
+3. **Package Contents** (if applicable)
+4. **System Specifications** (organized by category)
+5. **Environment** (if applicable)
+6. **Safety Warnings** (if applicable)
+7. **Compliance and Certifications** (if applicable)
+8. **Related Documentation** (links to setup, troubleshooting, etc.)
+
+---
+
+## Example: Complete Reference Structure
+
+Here's how a complete reference document should look:
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: TT-QuietBox, Blackhole
+    technology-concepts: specifications, requirements, hardware
+    document-type: Reference
+---
+
+# Specifications and Requirements
+
+This document provides system administrators and engineers with detailed technical specifications for the TT-QuietBox™ Blackhole™ (TW-04002) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
+
+## Package Contents
+
+The Tenstorrent TT-QuietBox Blackhole (TW-04002) system package includes the following items:
+
+* Tenstorrent TT-QuietBox Blackhole System
+* C13 Power Cable, 1.8m/6ft.
+* 8x QSFP-DD 800GbE Cable, 0.6m/2ft.
+* VGA-to-HDMI Adapter
+
+:::{warning}
+The TT-QuietBox is shipped in a wooden crate with a total weight of approximately 134 lbs (61 kg). The system itself weighs approximately 80 lbs (36 kg). At least two people are required to move and uncrate the system safely.
+:::
+
+For assembly instructions, refer to the [Unboxing and Setting Up the TT-QuietBox Workstation Guide](./setup.md).
+
+## System Specifications
+
+| Specification | Details |
+| :--- | :--- |
+| **CPU** | AMD EPYC™ 8124P (16 Cores / 32 Threads, up to 3.0 GHz) |
+| **Memory** | 512 GB (8x64 GB) DDR5-4800 ECC RDIMM |
+| **Storage** | 4 TB NVMe PCIe 4.0 x4 |
+| **Power Supply** | 1650W 80 PLUS Platinum |
+| **Operating System** | Ubuntu 22.04 LTS |
+| **System Dimensions** | 10" x 21.5" x 20" (W x D x H) / 254mm x 546mm x 508mm |
+| **System Weight** | 79.2 lbs / 35.9 kg |
+
+## Processing and Memory
+
+| Specification | Description |
+| :--- | :--- |
+| **AI Accelerator** | 4x Tenstorrent Blackhole™ p150c Tensix Processor |
+| **Host Processor** | AMD EPYC 8124P (16 cores) |
+| **Host Memory** | 512 GB (8x64 GB) DDR5-4800 ECC RDIMM |
+
+[Continue with additional categories...]
+```
+
+---
+
+## Writing Tips
+
+### Specification Tables
+
+**Do:**
+* Use consistent units throughout
+* Include both metric and imperial where standard practice
+* Be precise with measurements
+* Group related specifications together
+
+**Do Not:**
+* Mix units inconsistently
+* Use vague terms like "standard" or "typical"
+* Omit critical specifications
+* Include marketing language
+
+### Organization
+
+**Structure by:**
+* Physical characteristics (dimensions, weight)
+* Processing capabilities
+* Connectivity options
+* Power and environmental requirements
+* Compliance and certifications
+
+### Precision
+
+**Be Specific:**
+* "512 GB (8x64 GB) DDR5-4800 ECC RDIMM" not "512 GB RAM"
+* "10" x 21.5" x 20" (254mm x 546mm x 508mm)" not "approximately 10 inches"
+* "1650W 80 PLUS Platinum" not "high-efficiency power supply"
+
+---
+
+## Quality Assurance
+
+Before submitting your reference document, verify:
+
+1. **Accuracy:**
+   - [ ] All specifications verified against actual hardware/software
+   - [ ] Version numbers current
+   - [ ] Measurements correct
+   - [ ] Units consistent
+
+2. **Completeness:**
+   - [ ] All major categories covered
+   - [ ] No critical specifications missing
+   - [ ] Package contents listed (if applicable)
+
+3. **Clarity:**
+   - [ ] Tables clearly formatted
+   - [ ] Categories logically organized
+   - [ ] Technical terms defined on first use
+
+4. **Consistency:**
+   - [ ] Formatting consistent throughout
+   - [ ] Units used consistently
+   - [ ] Naming conventions followed
+
+---
+
+## Additional Resources
+
+* [Sphinx Documentation](https://www.sphinx-doc.org/)
+* [MyST Markdown Guide](https://mystmd.org/)
+
+---
+
+## Template Usage Notes
+
+1. **Copy this template** to create your reference document
+2. **Replace all bracketed placeholders** with actual content
+3. **Organize specifications** into logical categories
+4. **Use tables** for structured data
+5. **Verify all specifications** against actual hardware/software
+6. **Include cross-references** to related documentation
+
+Remember: Reference documentation is the definitive source of factual information. Accuracy and precision are paramount.
+

--- a/core/Resources/RELEASE_NOTES_TEMPLATE.md
+++ b/core/Resources/RELEASE_NOTES_TEMPLATE.md
@@ -1,0 +1,593 @@
+# Release Notes Template
+
+This template provides a structured rubric for creating Release Notes. Use this template as a starting point for documenting all user-facing changes for software or hardware releases.
+
+---
+
+## Template Structure
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Product Name, Version Number
+    technology-concepts: release notes, Concept1, Concept2, Concept3
+    document-type: Release Notes
+---
+
+# [Product Name] [Version Number] Release Notes
+
+[One-to-three sentence summary:]
+- What is this release?
+- Who should review these notes?
+- What are the key highlights?
+
+Example: "This document provides a chronological log of all user-facing changes in TT-Metalium™ Software v2.1.0. System administrators and developers should review these notes to understand new features, improvements, and breaking changes before upgrading."
+
+**Release Date:** [Date]
+**Previous Version:** [Previous version number]
+
+---
+
+## Highlights
+
+[Brief overview of the most significant changes:]
+
+* [Major feature or improvement 1]
+* [Major feature or improvement 2]
+* [Breaking change or important notice]
+
+---
+
+## New Features
+
+### [Feature Category 1]
+
+#### [Feature Name 1]
+
+[Description of the new feature:]
+
+* **What it does:** [Clear description]
+* **Why it matters:** [Benefit or use case]
+* **How to use:** [Brief usage instructions or link to documentation]
+
+[Optional: Code example]
+```python
+# Example usage
+feature_example()
+```
+
+#### [Feature Name 2]
+
+[Continue with additional features...]
+
+### [Feature Category 2]
+
+[Continue with additional feature categories...]
+
+---
+
+## Improvements
+
+### [Category 1: e.g., Performance]
+
+* **[Improvement 1]:** [Description of improvement and impact]
+* **[Improvement 2]:** [Description]
+
+### [Category 2: e.g., Usability]
+
+* **[Improvement 1]:** [Description]
+* **[Improvement 2]:** [Description]
+
+---
+
+## Bug Fixes
+
+### [Category 1: e.g., Compilation]
+
+* **Fixed:** [Bug description] - [Impact description]
+* **Fixed:** [Bug description] - [Impact description]
+
+### [Category 2: e.g., Runtime]
+
+* **Fixed:** [Bug description] - [Impact description]
+
+---
+
+## Breaking Changes
+
+:::{warning}
+[Important warning about breaking changes that require user action]
+:::
+
+### [Change Category 1]
+
+#### [Breaking Change Name]
+
+**What changed:**
+[Description of what changed]
+
+**Impact:**
+[Who is affected and how]
+
+**Migration path:**
+[Step-by-step instructions for updating code/configurations]
+
+[Optional: Before/After example]
+```python
+# Before (deprecated)
+old_function()
+
+# After (new way)
+new_function()
+```
+
+#### [Breaking Change Name 2]
+
+[Continue with additional breaking changes...]
+
+---
+
+## Deprecations
+
+### [Deprecated Feature 1]
+
+**Deprecated in:** [Version]
+**Removal planned for:** [Version or "Future release"]
+
+[Description of what is deprecated and why]
+
+**Migration:**
+[How to update code to use the replacement]
+
+### [Deprecated Feature 2]
+
+[Continue with additional deprecations...]
+
+---
+
+## Known Issues
+
+### [Issue Category 1]
+
+#### [Issue Title]
+
+**Description:** [Clear description of the issue]
+
+**Workaround:** [If available, provide a workaround]
+
+**Status:** [Fixed in vX.X.X / Under investigation / Planned for future release]
+
+#### [Issue Title 2]
+
+[Continue with additional known issues...]
+
+---
+
+## Security Updates
+
+[If applicable:]
+
+### [Security Issue 1]
+
+**CVE Number:** [If applicable]
+**Severity:** [Critical / High / Medium / Low]
+**Description:** [Description of the security issue]
+**Impact:** [Who is affected]
+**Resolution:** [How it was fixed or mitigated]
+
+---
+
+## Installation and Upgrade
+
+### System Requirements
+
+[Updated system requirements if changed:]
+
+* [Requirement 1]
+* [Requirement 2]
+
+### Upgrade Instructions
+
+[Step-by-step upgrade process:]
+
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+:::{important}
+[Any critical upgrade notes or prerequisites]
+:::
+
+### Downgrade Information
+
+[If applicable, information about downgrading:]
+
+:::{warning}
+[Downgrade warnings or limitations]
+:::
+
+---
+
+## API Changes
+
+[If applicable, detailed API changes:]
+
+### New APIs
+
+* **[API Name]:** [Description and usage]
+
+### Modified APIs
+
+* **[API Name]:** [What changed and migration path]
+
+### Removed APIs
+
+* **[API Name]:** [What was removed and replacement]
+
+---
+
+## Changelog
+
+[Chronological list of all changes, if detailed changelog is maintained:]
+
+### [Date] - [Category]
+
+* [Change description]
+* [Change description]
+
+---
+
+## Acknowledgments
+
+[If applicable:]
+
+* [Contributor or team name] - [Contribution]
+* [Contributor or team name] - [Contribution]
+
+---
+
+## Related Documentation
+
+* [Installation Guide](link-to-installation.md)
+* [Migration Guide](link-to-migration.md)
+* [API Reference](link-to-api.md)
+
+---
+
+## Support
+
+For questions about this release or to report issues, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1)
+```
+
+---
+
+## Quality Checklist
+
+Use this checklist to ensure your release notes meet standards:
+
+### Document Structure
+
+- [ ] **Title:** Includes product/tool name and version number
+  - ✅ Correct: "TT-Metalium™ Software v2.1.0 Release Notes"
+  - ❌ Incorrect: "Release Notes" (missing product and version)
+
+- [ ] **Summary:** One-to-three sentences answering:
+  - [ ] What is this release?
+  - [ ] Who should review these notes?
+  - [ ] What are the key highlights?
+
+- [ ] **Metadata:** Complete myst frontmatter with:
+  - [ ] Product names (include version number)
+  - [ ] Technology concepts (include "release notes" plus relevant keywords)
+  - [ ] Document type: "Release Notes"
+
+### Content Quality
+
+- [ ] **Completeness:**
+  - [ ] All user-facing changes documented
+  - [ ] Breaking changes clearly marked
+  - [ ] Migration paths provided
+  - [ ] Known issues listed
+
+- [ ] **Clarity:**
+  - [ ] Changes clearly described
+  - [ ] Impact explained
+  - [ ] Migration steps actionable
+  - [ ] Technical terms defined
+
+- [ ] **Organization:**
+  - [ ] Changes grouped by category
+  - [ ] Most important changes first
+  - [ ] Chronological where appropriate
+
+### Formatting
+
+- [ ] **Headings:** Sequential hierarchy (H2 → H3 → H4, no skipping)
+- [ ] **Lists:** Bulleted lists for feature lists and changes
+- [ ] **Code Blocks:** Used for code examples and migration paths
+- [ ] **Admonitions:** Used for warnings about breaking changes
+
+---
+
+## Required Sections Reference
+
+Every Release Notes document should include:
+
+1. **Title** (Product name and version)
+2. **Summary** (What release + Who should review)
+3. **Release Date** and **Previous Version**
+4. **Highlights** (Key changes overview)
+5. **New Features** (Organized by category)
+6. **Improvements** (Organized by category)
+7. **Bug Fixes** (Organized by category)
+8. **Breaking Changes** (If any, with migration paths)
+9. **Deprecations** (If any, with migration guidance)
+10. **Known Issues** (Current limitations)
+11. **Installation and Upgrade** (Instructions)
+12. **Related Documentation** (Links to guides)
+
+---
+
+## Example: Complete Release Notes Structure
+
+Here's how complete release notes should look:
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: TT-Metalium, v2.1.0
+    technology-concepts: release notes, compilation, API, performance
+    document-type: Release Notes
+---
+
+# TT-Metalium™ Software v2.1.0 Release Notes
+
+This document provides a chronological log of all user-facing changes in TT-Metalium™ Software v2.1.0. System administrators and developers should review these notes to understand new features, improvements, and breaking changes before upgrading.
+
+**Release Date:** November 15, 2024
+**Previous Version:** v2.0.5
+
+---
+
+## Highlights
+
+* New compiler optimizations improve performance by up to 30% for certain workloads
+* Enhanced API with improved error handling
+* Breaking change: Updated tensor format requires code migration
+
+---
+
+## New Features
+
+### Compilation
+
+#### Enhanced Optimization Passes
+
+**What it does:** New compiler optimization passes that improve kernel performance for matrix multiplication operations.
+
+**Why it matters:** Reduces execution time for common AI/ML workloads.
+
+**How to use:** No code changes required. Optimizations are applied automatically during compilation.
+
+### API
+
+#### Improved Error Messages
+
+**What it does:** Error messages now include specific file locations and line numbers.
+
+**Why it matters:** Faster debugging and issue resolution.
+
+**How to use:** Errors automatically include enhanced context.
+
+---
+
+## Improvements
+
+### Performance
+
+* **Matrix Operations:** Improved performance by 25-30% for large matrix multiplications
+* **Memory Management:** Reduced memory overhead by 15% in typical workloads
+
+### Usability
+
+* **CLI Output:** More readable command-line output with color coding
+* **Documentation:** Updated API documentation with additional examples
+
+---
+
+## Bug Fixes
+
+### Compilation
+
+* **Fixed:** Compiler crash when processing nested loops - Resolves compilation failures for certain model architectures
+* **Fixed:** Incorrect memory allocation for large tensors - Prevents out-of-memory errors
+
+### Runtime
+
+* **Fixed:** Memory leak in long-running processes - Improves system stability
+
+---
+
+## Breaking Changes
+
+:::{warning}
+This release includes breaking changes that require code updates. Review the migration guide before upgrading.
+:::
+
+### API Changes
+
+#### Tensor Format Update
+
+**What changed:**
+The default tensor format has changed from row-major to column-major for improved performance.
+
+**Impact:**
+All code that directly accesses tensor data will need updates.
+
+**Migration path:**
+1. Review your code for direct tensor data access
+2. Update indexing to match new format
+3. Test thoroughly before deploying
+
+```python
+# Before (row-major)
+data = tensor[i, j]
+
+# After (column-major)
+data = tensor[j, i]
+```
+
+See the [Migration Guide](./migration-v2.1.md) for detailed instructions.
+
+---
+
+## Deprecations
+
+### Legacy Compiler Flags
+
+**Deprecated in:** v2.1.0
+**Removal planned for:** v2.2.0
+
+The `--legacy-format` flag is deprecated. Use the new `--tensor-format` option instead.
+
+**Migration:**
+Replace `--legacy-format` with `--tensor-format=legacy` in your build scripts.
+
+---
+
+## Known Issues
+
+### Compilation
+
+#### Issue: Compiler Warning for Nested Functions
+
+**Description:** The compiler generates warnings (not errors) for deeply nested function definitions, even when code is valid.
+
+**Workaround:** Suppress warnings using `--suppress-warnings` flag if needed.
+
+**Status:** Under investigation, planned fix for v2.1.1
+
+---
+
+## Installation and Upgrade
+
+### System Requirements
+
+* Python 3.8 or higher
+* CUDA 11.8 or higher
+* 16 GB RAM minimum
+
+### Upgrade Instructions
+
+1. Backup your current configuration files
+2. Uninstall previous version: `pip uninstall tt-metalium`
+3. Install new version: `pip install tt-metalium==2.1.0`
+4. Run migration script: `tt-metalium-migrate --from 2.0.5`
+
+:::{important}
+Review breaking changes section before upgrading. Some code modifications may be required.
+:::
+
+---
+
+## Related Documentation
+
+* [Installation Guide](./installation.md)
+* [Migration Guide](./migration-v2.1.md)
+* [API Reference](./api-reference.md)
+```
+
+---
+
+## Writing Tips
+
+### Feature Descriptions
+
+**Do:**
+* Clearly state what the feature does
+* Explain why it matters (benefit)
+* Provide usage instructions or links
+* Include code examples when helpful
+
+**Do Not:**
+* Use marketing language
+* Omit usage information
+* Assume prior knowledge
+
+### Breaking Changes
+
+**Do:**
+* Clearly mark as breaking changes
+* Explain what changed
+* Describe impact on users
+* Provide step-by-step migration path
+* Include before/after examples
+
+**Do Not:**
+* Bury breaking changes in other sections
+* Skip migration instructions
+* Assume users will figure it out
+
+### Bug Fixes
+
+**Do:**
+* Describe the bug clearly
+* Explain the impact
+* Note if a workaround existed
+
+**Do Not:**
+* Use vague descriptions
+* Omit impact information
+
+---
+
+## Quality Assurance
+
+Before submitting your release notes, verify:
+
+1. **Completeness:**
+   - [ ] All user-facing changes documented
+   - [ ] Breaking changes clearly marked
+   - [ ] Migration paths provided
+   - [ ] Known issues listed
+
+2. **Accuracy:**
+   - [ ] Version numbers correct
+   - [ ] Dates accurate
+   - [ ] Code examples tested
+   - [ ] Links functional
+
+3. **Clarity:**
+   - [ ] Changes clearly described
+   - [ ] Impact explained
+   - [ ] Migration steps actionable
+   - [ ] Technical terms defined
+
+4. **Organization:**
+   - [ ] Changes grouped logically
+   - [ ] Most important changes first
+   - [ ] Consistent formatting
+
+---
+
+## Additional Resources
+
+* [Sphinx Documentation](https://www.sphinx-doc.org/)
+* [MyST Markdown Guide](https://mystmd.org/)
+
+---
+
+## Template Usage Notes
+
+1. **Copy this template** to create your release notes
+2. **Replace all bracketed placeholders** with actual content
+3. **Organize changes** by category (Features, Improvements, Bug Fixes)
+4. **Clearly mark breaking changes** with warnings
+5. **Provide migration paths** for all breaking changes
+6. **Include upgrade instructions** with prerequisites
+7. **List known issues** with workarounds when available
+
+Remember: Release notes are the primary communication channel for changes. Clarity and completeness help users upgrade successfully.
+

--- a/core/Resources/TROUBLESHOOTING_GUIDE_TEMPLATE.md
+++ b/core/Resources/TROUBLESHOOTING_GUIDE_TEMPLATE.md
@@ -1,0 +1,407 @@
+# Troubleshooting Guide Template
+
+This template provides a structured rubric for creating Troubleshooting Guides. Use this template as a starting point for all problem-and-solution documentation.
+
+---
+
+## Template Structure
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: Product Name, Alternative Name, Technology Name
+    technology-concepts: troubleshooting, Concept1, Concept2, Concept3
+    document-type: Troubleshooting
+---
+
+# Troubleshooting [Problem Category or Product Name] Issues
+
+[One-to-three sentence summary that answers:]
+- Who is this for?
+- What problems does it help resolve?
+
+Example: "This guide assists users in diagnosing and resolving common hardware issues with the TT-QuietBox™ system, including system instability, boot failures, and long-term maintenance tasks such as coolant refilling."
+
+## [Problem 1: Descriptive Problem Name]
+
+[Brief description of when this problem occurs or what symptoms indicate this issue.]
+
+**Symptoms:**
+* [Symptom 1]
+* [Symptom 2]
+* [Symptom 3]
+
+**Cause:** [Clear explanation of what causes the problem]
+
+**Solution:** [Brief summary of the solution]
+
+[Step-by-step resolution:]
+
+1. [Step 1 description]
+2. [Step 2 description]
+3. [Step 3 description]
+
+[Optional: Include code blocks for verification]
+```bash
+$ verification-command
+```
+
+[Expected output]
+```
+Expected output here
+```
+
+[Optional: Include images showing the problem or solution]
+![](problem_image.png)
+
+[Optional: Include warnings or notes]
+:::{warning}
+[Warning about potential risks or data loss]
+:::
+
+:::{note}
+[Additional context or helpful information]
+:::
+
+**If this does not resolve the issue:**
+[Link to support or additional troubleshooting steps]
+
+---
+
+## [Problem 2: Descriptive Problem Name]
+
+[Continue with the same structure for each problem:]
+
+**Symptoms:**
+* [Symptom 1]
+* [Symptom 2]
+
+**Cause:** [Explanation]
+
+**Solution:** [Summary]
+
+[Step-by-step resolution]
+
+---
+
+## [Problem 3: Descriptive Problem Name]
+
+[Continue pattern for all problems]
+
+---
+
+## Diagnostic Tools and Commands
+
+[If applicable, include common diagnostic commands:]
+
+### Verifying Hardware Recognition
+
+```bash
+$ diagnostic-command
+```
+
+**Expected Output:**
+```
+Expected output showing successful recognition
+```
+
+### Checking System Status
+
+```bash
+$ status-command
+```
+
+**Expected Output:**
+```
+Expected status output
+```
+
+---
+
+## Common Questions
+
+[FAQ-style section for common questions:]
+
+### [Question 1: How do I...?]
+
+[Clear, direct answer]
+
+### [Question 2: Which... should I use?]
+
+[Answer with specific recommendations and reasoning]
+
+---
+
+## Need Additional Support?
+
+If you encounter any issues, or have a question that is not covered in the documentation, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
+
+---
+
+## Related Documentation
+
+* [Setup Guide](./setup.md)
+* [Technical Specifications](./specifications.md)
+* [Additional Troubleshooting Resources](link-to-resources.md)
+```
+
+---
+
+## Quality Checklist
+
+Use this checklist to ensure your troubleshooting guide meets standards:
+
+### Document Structure
+
+- [ ] **Title:** Describes the problem or error message
+  - ✅ Correct: "Resolving PCIe Link Training Errors"
+  - ✅ Correct: "Troubleshooting Common Hardware Issues"
+  - ❌ Incorrect: "Problems" (too vague)
+
+- [ ] **Summary:** One-to-three sentences answering:
+  - [ ] Who is this for?
+  - [ ] What problems does it help resolve?
+
+- [ ] **Metadata:** Complete myst frontmatter with:
+  - [ ] Product names (comma-separated, all variations)
+  - [ ] Technology concepts (include "troubleshooting" plus relevant keywords)
+  - [ ] Document type: "Troubleshooting"
+
+### Content Quality
+
+- [ ] **Problem-Solution Structure:** Each issue includes:
+  - [ ] Clear symptoms
+  - [ ] Root cause explanation
+  - [ ] Step-by-step solution
+  - [ ] Verification steps
+
+- [ ] **Clarity:**
+  - [ ] Symptoms clearly described
+  - [ ] Causes explained in understandable terms
+  - [ ] Solutions are actionable
+  - [ ] Steps are numbered and sequential
+
+- [ ] **Completeness:**
+  - [ ] Common issues covered
+  - [ ] Diagnostic commands included
+  - [ ] Support escalation path provided
+
+### Formatting
+
+- [ ] **Headings:** Sequential hierarchy (H2 → H3 → H4, no skipping)
+- [ ] **Lists:** 
+  - [ ] Bulleted lists for symptoms
+  - [ ] Numbered lists for solution steps
+- [ ] **Code Blocks:** 
+  - [ ] Diagnostic commands included
+  - [ ] Expected output shown
+- [ ] **Admonitions:** Used appropriately for warnings and notes
+
+---
+
+## Required Sections Reference
+
+Every Troubleshooting Guide should include:
+
+1. **Title** (Describes the problem or error)
+2. **Summary** (Who + What problems resolved)
+3. **Problem-Solution Sections** (Each with Symptoms, Cause, Solution)
+4. **Diagnostic Tools** (if applicable)
+5. **Common Questions** (FAQ-style, if applicable)
+6. **Support Information** (How to get additional help)
+7. **Related Documentation** (Links to setup, specifications, etc.)
+
+---
+
+## Example: Complete Troubleshooting Structure
+
+Here's how a complete troubleshooting guide should look:
+
+```markdown
+---
+myst:
+  html_meta:
+    product-name: TT-QuietBox
+    technology-concepts: troubleshooting, BIOS, PCIe, coolant, maintenance
+    document-type: Troubleshooting
+---
+
+# Troubleshooting Common Hardware Issues
+
+This guide assists users in diagnosing and resolving common hardware issues with the TT-QuietBox™ system, including system instability, boot failures, and long-term maintenance tasks such as coolant refilling.
+
+## Resolving System Instability or Random Reboots After a BIOS Change
+
+If your system experiences random reboots or stability issues after a BIOS update or reset, a specific setting may be incorrectly configured.
+
+**Symptoms:**
+* Random system reboots
+* System instability
+* Issues occur after BIOS update or reset
+
+**Cause:** The PCIe Advanced Error Reporting (AER) mechanism is not configured to allow the operating system to handle error reporting. This misconfiguration can interfere with Tenstorrent's system management software.
+
+**Solution:** Set the reporting mechanism to **OS First**.
+
+1. Enter the system **BIOS** during boot.
+2. Navigate to **Advanced** \> **AMD CBS** \> **NBIO Common Options** \> **NBIO RAS Common Options**.
+3. Locate the setting for **PCIe AER Reporting Mechanism**.
+4. Change the value to **OS First**.
+5. Save changes and exit the **BIOS**.
+
+---
+
+## Resolving Boot Failures or Undetected Cards
+
+If your system does not boot, or if Tenstorrent hardware does not appear in software utilities such as `tt-smi`, the PCIe cards may be unseated.
+
+:::{note}
+Extended boot times are normal during the first boot or after a power loss event. System memory training can take up to 10 minutes to complete. This behavior does not indicate a boot failure.
+:::
+
+**Symptoms:**
+* System does not boot
+* Hardware not detected in `tt-smi`
+* POST codes indicating hardware issues
+
+**Cause:** One or more PCIe cards may have become loose during shipment or relocation.
+
+**Solution:** Reseat the PCIe cards manually.
+
+:::{warning}
+This procedure requires technical expertise and careful handling to avoid damaging system components. Proceed with caution.
+:::
+
+### Required Tools
+
+* 2.5mm security hex bit
+* 2.0mm security hex bit
+* Phillips head screwdriver
+
+### Reseating Procedure
+
+1. Place the system on its side. Use a 2.5mm security hex bit to unscrew the chassis top panel and access the PCIe cards.
+   
+   ![](qb_1_1.jpg)
+
+2. Carefully remove the front glass panel and set it aside in a safe location.
+   
+   ![](qb_1_2.png)
+
+3. [Continue with remaining steps...]
+
+**Verification:**
+```bash
+$ tt-smi
+```
+
+You should see all cards listed in the output.
+
+**If this does not resolve the issue:**
+[Raise a support request](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) with details about your system configuration.
+
+---
+
+## Common Questions
+
+### How do I choose between different product variants?
+
+[Clear answer with specific recommendations]
+
+### Which cables should I purchase?
+
+[Answer with validated options and links if applicable]
+```
+
+---
+
+## Writing Tips
+
+### Problem Descriptions
+
+**Do:**
+* Start with clear symptom description
+* Use specific error messages when available
+* Include context about when the problem occurs
+* List all relevant symptoms
+
+**Do Not:**
+* Use vague descriptions: "system not working"
+* Assume the user knows technical terms without explanation
+* Skip symptom descriptions
+
+### Solution Steps
+
+**Do:**
+* Number steps sequentially
+* Be specific: "Navigate to Advanced > AMD CBS" not "go to BIOS settings"
+* Include verification steps
+* Show expected output
+
+**Do Not:**
+* Combine multiple actions in one step
+* Skip verification
+* Assume prior knowledge
+
+### Cause Explanations
+
+**Do:**
+* Explain the root cause clearly
+* Use technical accuracy
+* Help users understand why the problem occurs
+
+**Do Not:**
+* Blame the user
+* Use overly technical jargon without explanation
+* Skip cause explanation
+
+---
+
+## Quality Assurance
+
+Before submitting your troubleshooting guide, verify:
+
+1. **Accuracy:**
+   - [ ] All solutions tested and working
+   - [ ] Diagnostic commands verified
+   - [ ] Expected outputs accurate
+   - [ ] Links functional
+
+2. **Completeness:**
+   - [ ] Common issues covered
+   - [ ] Symptoms clearly described
+   - [ ] Solutions provided for all listed problems
+   - [ ] Support escalation path included
+
+3. **Clarity:**
+   - [ ] Symptoms easy to identify
+   - [ ] Solutions actionable
+   - [ ] Technical terms explained
+   - [ ] Steps unambiguous
+
+4. **Organization:**
+   - [ ] Problems logically grouped
+   - [ ] Most common issues first
+   - [ ] Related problems grouped together
+
+---
+
+## Additional Resources
+
+* [Sphinx Documentation](https://www.sphinx-doc.org/)
+* [MyST Markdown Guide](https://mystmd.org/)
+
+---
+
+## Template Usage Notes
+
+1. **Copy this template** to create your troubleshooting guide
+2. **Replace all bracketed placeholders** with actual content
+3. **Organize problems** by category or frequency
+4. **Test all solutions** before documenting
+5. **Include diagnostic commands** for verification
+6. **Provide clear escalation paths** for unresolved issues
+
+Remember: Troubleshooting guides should help users solve problems quickly. Clarity and accuracy are essential.
+

--- a/core/systems/index.rst
+++ b/core/systems/index.rst
@@ -9,3 +9,4 @@ Systems
    t3000/index
    t1000/index
    t7000/index
+   tenstorrent-galaxy/index

--- a/core/systems/tenstorrent-galaxy/README_PDF.md
+++ b/core/systems/tenstorrent-galaxy/README_PDF.md
@@ -1,0 +1,30 @@
+# Tenstorrent Galaxy PDF User Guide
+
+## Adding the PDF
+
+1. Place your PDF file in this directory (`core/systems/tenstorrent-galaxy/`) with the filename `tenstorrent_galaxy_user_guide.pdf`
+2. The PDF will automatically be copied to the build output during documentation generation
+3. The download link is already configured in `index.rst` using Sphinx's `:download:` directive
+
+## Alternative: Custom Filename
+
+If your PDF has a different name, update the link in `index.rst`:
+
+```rst
+:download:`Tenstorrent Galaxy User Guide <your_filename.pdf>`
+```
+
+## Alternative: Link in Markdown
+
+You can also add download links in any `.md` file:
+
+```markdown
+[Download Tenstorrent Galaxy User Guide](tenstorrent_galaxy_user_guide.pdf)
+```
+
+Or with a custom label:
+
+```markdown
+[Download the complete user guide](tenstorrent_galaxy_user_guide.pdf)
+```
+

--- a/core/systems/tenstorrent-galaxy/index.rst
+++ b/core/systems/tenstorrent-galaxy/index.rst
@@ -1,0 +1,16 @@
+Tenstorrent Galaxy
+=======================================
+
+.. toctree::
+   :maxdepth: 2
+
+   specifications
+   installation-power-environmental
+   software-setup-configuration
+
+Download User Guide
+--------------------
+
+.. raw:: html
+
+   <a href="tenstorrent_galaxy_user_guide.pdf" target="_blank" download>Tenstorrent Galaxy User Guide</a>

--- a/core/systems/tenstorrent-galaxy/installation-power-environmental.md
+++ b/core/systems/tenstorrent-galaxy/installation-power-environmental.md
@@ -1,0 +1,119 @@
+---
+myst:
+  html_meta:
+    product-name: Tenstorrent Galaxy Server, Wormhole Networked AI Processor
+    technology-concepts: Installation, Power Supply, Topology, Networking
+    document-type: Reference, Prerequisites
+---
+
+# Installation, Power, and Environmental Requirements
+
+This reference documentation provides professional installers and IT administrators with the critical physical, power, environmental, and networking specifications required to successfully prepare for and deploy the Tenstorrent Galaxy™ Server.
+
+## Physical Specifications and Packaging
+
+### Packaging and Dimensions
+
+The Tenstorrent Galaxy™ Server ships with the following dimensions and weight:
+
+| Specification | Value |
+| :--- | :--- |
+| **Total Server Weight** | 119 kg (262 lbs) |
+| **Chassis Dimensions (H x W x D)** | 447 mm x 266.7 mm x 884 mm |
+
+The package contains the following items:
+
+*   1x Server unit (TG-00002)
+    *   4x Power supply cords (3m IEC320-C20 3P 250V UL)
+*   1x Static Rail kit
+    *   4x **M5x10 screws**
+*   Tenstorrent Ethernet cables (TX-02001 rev 1 or rev 2)
+*   User-specified power cables (determined at the time of purchase)
+
+:::{important}
+The Server contains a self-contained Class 1 Laser within the optical transceiver module. If replacement is necessary, use only a certified optical fiber transceiver Class 1 Laser product.
+:::
+
+:::{warning}
+Use only Tenstorrent-recommended cables with this Server. Replacement cables must match the type and wire gauge of the original cables shipped with the Server. Use of unapproved or alternative cables may result in equipment damage, dangerous operating conditions, or non-compliant operation.
+:::
+
+### Installation Requirements
+
+Installation must be performed by a trained, qualified professional within a restricted access area. The professional installer assumes full responsibility for complying with all local regulatory and safety requirements during deployment.
+
+**Required Installation Equipment**
+
+Ensure you have the following equipment available before beginning installation:
+
+*   Standard pallet jack, skid steer, or pump truck
+*   Server Lift (mandatory)
+*   **Phillips head screwdriver**
+
+Because the Server weighs 119 kg (262 lbs), use of a Server Lift is mandatory. Tenstorrent strongly recommends that installation procedures involve a minimum of two personnel to prevent personal injury and damage to the Server.
+
+### Rack Specifications
+
+The Tenstorrent Galaxy Server, utilizing the Wormhole™ Networked AI Processor, must be installed in an EIA-compliant 19" (482.6 mm) rack. If alternative racking solutions are required, contact your Tenstorrent representative prior to installation.
+
+## Power and Environmental Requirements
+
+### Power Requirements
+
+The Server's internal AC/DC power supply is comprised of four 4000-watt, 80 Plus Titanium, hot-plug Power Supply Units (PSUs) operating in a 3+1 redundant configuration.
+
+| Power Specification | Value |
+| :--- | :--- |
+| **Peak Power Consumption** | 12 kW |
+| **PSU Redundancy** | 3+1 |
+| **Power Cord Length** | 3 meters |
+
+**Output Specifications per PSU**
+
+*   **Main Output (V1):** 54 Vdc, regulated, >70 A
+*   **Auxiliary Standby Output (Vsb):** 12 Vdc, 3 A
+
+PSU cables must connect to grounded socket-outlets.
+
+### Environmental Requirements
+
+The following conditions are necessary for ideal Server operation:
+
+| Environmental Specification | Operating Condition | Storage Condition |
+| :--- | :--- | :--- |
+| **Temperature (dry-bulb)** | 5°C to 35°C (41°F to 95°F) | -40°C to 70°C (-40°F to 158°F) |
+| **Relative Humidity** | 20% to 85% | 10% to 95% |
+
+**Thermal and Airflow Metrics**
+
+Performance metrics are based on a typical strenuous workload at 35°C ambient temperature:
+
+| Metric | Value |
+| :--- | :--- |
+| **Maximum Heat Output** | 34,633 BTU/hr |
+| **Airflow Requirement** | 1229 CFM @ 80% fan PWM |
+
+## Connectivity
+
+### Network Topology
+
+The Server supports both grid and torus network topologies for inter-chip communication:
+
+*   ***Torus Topology***: This configuration uses internal and external cables to connect individual processing chips. Torusing is recommended for high-performance operations as it decreases latency by reducing the hop count between *Tensix cores*.
+
+*   ***Grid Topology***: The default, cable-free configuration.
+
+Both grid and torus topologies support expansion across multiple systems using specialized cabling techniques. Contact your Tenstorrent representative to discuss the optimal topology for your specific workload requirements.
+
+### Ethernet Cabling and Limitations
+
+The Server ships with a recommended cabling configuration, but users may customize the configuration as needed.
+
+**Supported Maximum Cable Lengths**
+
+| Cable Type | Maximum Length |
+| :--- | :--- |
+| **Direct Attach Copper (DAC)** | 2.5 meters |
+| **Active Optical Cable (AOC)** | 30 meters |
+
+For installations involving multiple Tenstorrent Galaxy Servers, Tenstorrent can provide multi-system cabling diagrams and examples. Contact your Tenstorrent representative for assistance with complex deployment planning.

--- a/core/systems/tenstorrent-galaxy/software-setup-configuration.md
+++ b/core/systems/tenstorrent-galaxy/software-setup-configuration.md
@@ -1,0 +1,28 @@
+---
+myst:
+  html_meta:
+    product-name: Tenstorrent Galaxy, Wormhole™ Networked AI Processor
+    technology-concepts: Software Setup, AI/ML Infrastructure
+    document-type: Explanation, Reference
+---
+
+# Software Setup and Configuration
+
+This guide provides developers with essential references and information necessary for configuring the software stack on Tenstorrent Galaxy systems.
+
+## Software Installation Overview
+
+Tenstorrent simplifies the setup process for the core software stack by providing the `tt-installer` bash script. The installer automates the configuration steps and supports common Linux distributions, including Ubuntu, Fedora, and Debian.
+
+## Detailed Setup Instructions
+
+Detailed, step-by-step instructions for installing and configuring the software stack on the Tenstorrent Galaxy hardware are available on our GitHub:
+
+[Tenstorrent Galaxy Software Guide](https://github.com/tenstorrent/tt-metal/blob/main/docs/source/tech_reports/WH_Galaxy/Galaxy_WH_6U_SW_Guide.md)
+
+## Supported Models and Development
+
+The `tt-metal` repository serves as the central hub for the Tenstorrent software ecosystem. Developers should reference the repository landing page to view the latest supported neural network models and recent feature updates compatible with Tenstorrent Galaxy systems.
+
+[TT-Metal Repository](https://github.com/tenstorrent/tt-metal)
+

--- a/core/systems/tenstorrent-galaxy/specifications.md
+++ b/core/systems/tenstorrent-galaxy/specifications.md
@@ -1,0 +1,85 @@
+---
+myst:
+  html_meta:
+    product-name: TG-00002, Wormhole™ Networked AI Processor, Tensix core
+    technology-concepts: AI Acceleration, HPC, Server Architecture, Networking
+    document-type: Reference
+---
+
+# Technical Specifications
+
+This reference provides system administrators and hardware planners with the detailed technical specifications for the TG-00002 system, including physical dimensions, component configuration, and connectivity options.
+
+## System Specifications
+
+The following table details the core specifications and physical characteristics of the TG-00002 system.
+
+| Specification | Description |
+| :--- | :--- |
+| **Model Number** | TG-00002 |
+| **Form Factor** | 6RU Rackmount (Air-cooled) |
+| **Chassis Dimensions (W x H x D)** | 447 mm x 266.7 mm x 884.5 mm (17.60" x 10.75" x 34.8") |
+| **Mainboard Form Factor (W x L)** | 147 mm x 485 mm |
+| **Tray Form Factor (W x L)** | 431 mm x 600 mm (4 Trays total) |
+
+## Processing and Memory
+
+| Specification | Description |
+| :--- | :--- |
+| **AI Accelerator** | 32x Wormhole™ Networked AI Processors (8 processors per tray across 4 trays) |
+| **AI Power Consumption** | 170W per Wormhole processor |
+| **Host Processor** | AMD EPYC 9354P (32 cores) |
+| **Host Processor Details** | Socket SP5/LGA 6096; up to 3.8 GHz clock speed; 280W TDP |
+| **Host Memory** | 576 GB (6x 96 GB) DDR5-4800 ECC RDIMM (6 slots populated) |
+| **Video** | ASPEED AST2600 with integrated 1 GB DDR4 video memory |
+| **Maximum Display Resolution** | 1920x1200p @ 60 Hz (32 bpp) |
+
+## Storage
+
+The TG-00002 system supports both internal system storage and expandable, hot-plug storage options.
+
+| Specification | Description |
+| :--- | :--- |
+| **Internal M.2 Storage** | 2x M.2 2280 NVMe PCIe 3.0/4.0 x4 Drive Slots |
+| **M.2 Configuration** | Populated with 2x 960 GB M.2 2280 NVMe drives |
+| **Expandable E1.S Bays** | 4x Hot-Plug E1.S 9.5 mm/15 mm PCIe 4.0 x4 SSD Drive Bays |
+| **E1.S Configuration** | Populated with 4x 4 TB or 4x 8 TB E1.S drives |
+| **BMC Storage** | 1x SD card slot with included 32 GB SD card |
+
+## Connectivity
+
+### Internal Connectivity
+
+| Specification | Description |
+| :--- | :--- |
+| **Internal PCIe** | 4x trays utilize PCIe 4.0 (one x8 lane, seven x1 lanes per tray) |
+| **Internal AI Networking** | 6x 400 Gbps QSFP-DD ports per tray |
+| **Internal Sync/Data** | 8x 56G PAM4 links per tray |
+
+### External Networking
+
+| Specification | Description |
+| :--- | :--- |
+| **Management LAN** | 1x Dedicated 1 GbE BMC management LAN port |
+| **High-Speed Networking** | 2x 100/50/40/25/10 GbE QSFP-DD ports via Broadcom N2100G |
+| **Additional Network Slot** | 1x OCP 3.0 NIC slot |
+
+## Input/Output (I/O)
+
+### Front I/O
+
+| Specification | Description |
+| :--- | :--- |
+| **User Interface** | 1x Power button/LED; 1x Reset button; 1x ID button/LED |
+| **Status Indicators** | 1x System Status LED; 1x Tray Status LED |
+| **USB Ports** | 2x USB 3.0 Type-A ports |
+| **Other** | 1x Bezel connector |
+
+### Rear I/O
+
+| Specification | Description |
+| :--- | :--- |
+| **Video** | 1x DisplayPort 1.1a |
+| **USB Ports** | 1x USB 3.0 Type-A port (from CPU) |
+| **Management Port** | 1x Dedicated 1 GbE BMC LAN port |
+| **Debug Port** | 1x COM port (USB Type-C) |


### PR DESCRIPTION
This PR is for 2 commits:

- Add Tenstorrent Galaxy section and resources to the doc site, including a downloadable User Guide. This unlocks the ability to share our existing assets @dhelmuthTT's been creating to a wider audience, and creates a home for future resources.

- Add a "resources" section to our repo to support the technical writers, providing markdown templates for How-to, Troubleshooting, and Reference documentation.