### PR TITLE
Add a step in page_deploy workflow to fetch latest tt-kmd, tt-firmware, tt-system-tools

### DIFF
--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -29,6 +29,24 @@ jobs:
           python3 -m venv .docs-env
           source .docs-env/bin/activate
           pip install -r requirements.txt
+
+      - name: Fetch latest versions from GitHub releases
+        run: |
+          # Fetch latest tt-kmd version
+          KMD_VERSION=$(curl -s https://api.github.com/repos/tenstorrent/tt-kmd/releases/latest | jq -r '.tag_name' | sed 's/^ttkmd-//')
+          echo "Latest tt-kmd version: $KMD_VERSION"
+          echo "$KMD_VERSION" > syseng/kmd.version
+
+          # Fetch latest tt-firmware version
+          FW_VERSION=$(curl -s https://api.github.com/repos/tenstorrent/tt-firmware/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          echo "Latest tt-firmware version: $FW_VERSION"
+          echo "$FW_VERSION" > syseng/firmware.version
+
+          # Fetch latest tt-system-tools version
+          SYS_TOOLS_VERSION=$(curl -s https://api.github.com/repos/tenstorrent/tt-system-tools/releases/latest | jq -r '.tag_name' | sed 's/^v//')
+          echo "Latest tt-system-tools version: $SYS_TOOLS_VERSION"
+          echo "$SYS_TOOLS_VERSION" > syseng/sys_tools.version
+
       - name: Build documentation
         run: |
           source .docs-env/bin/activate


### PR DESCRIPTION
# Issue

https://github.com/tenstorrent/tenstorrent.github.io/issues/114

We have a very outdated docs with outdated versions for tt-kmd, tt-firmware, tt-system-tools.

Some users use this docs when installing drivers on non-Ubuntu systems like Debian.

Old versions won't work.

We need to update the docs.

But manually updating the docs every release would make much work.

# Actions

- Add a step in deployment workflow to fetch latest tt-kmd, tt-firmware, tt-system-tools.