### PR TITLE
Update link formats on card menu pages

### DIFF
--- a/core/aibs/blackhole/index.rst
+++ b/core/aibs/blackhole/index.rst
@@ -2,25 +2,25 @@
 Blackhole™ PCIe Cards
 =======================================
 
-.. toctree::
-   :hidden:
-
-   installation
-   specifications
-   support
 
 Getting Started
 ---------------
 
-- :doc:`Hardware Installation <installation>`
-- `Software Setup <http://docs.tenstorrent.com/getting-started/README.html>`_
+.. toctree::
+   :maxdepth: 1
+   
+   installation
+   Software Setup </getting-started/README>
+
 
 Reference Materials
 -------------------
-
-- :doc:`Specifications and Requirements <specifications>`
-- :doc:`Troubleshooting Common Hardware Issues <support>`
-- `Regulatory Compliance Statements <https://docs.tenstorrent.com/aibs/compliance.html>`_
+.. toctree::
+   :maxdepth: 1
+   
+   specifications
+   support
+   /aibs/compliance
 
 Accessories
 -----------

--- a/core/aibs/compliance.md
+++ b/core/aibs/compliance.md
@@ -6,7 +6,7 @@ myst:
     document-type: Reference
 ---
 
-# **Regulatory Compliance Statements**
+# Regulatory Compliance Statements
 
 This document provides regulatory compliance information for specific Tenstorrent products, including models e75, e150, n150d, n150s, n300d, n300s, p100a, p150b, and p150c. It outlines the standards and regulations with which these devices comply in various regions, assisting users in understanding compliance requirements for proper installation and operation.
 

--- a/core/aibs/wormhole/index.rst
+++ b/core/aibs/wormhole/index.rst
@@ -5,15 +5,20 @@ Wormhole™ PCIe Cards
 Getting Started
 ---------------
 
-- `Hardware Installation <https://docs.tenstorrent.com/aibs/wormhole/installation.html>`_
-- `Software Setup <http://docs.tenstorrent.com/getting-started/README.html>`_
+.. toctree::
+   :maxdepth: 1
+   
+   installation
+   Software Setup </getting-started/README>
 
 Reference Materials
 -------------------
 
-- `Specifications and Requirements <https://docs.tenstorrent.com/aibs/wormhole/specifications.html>`_
--  Troubleshooting Common Hardware Issues - TBD
-- `Regulatory Compliance Statements <https://docs.tenstorrent.com/aibs/compliance.html>`_
+.. toctree::
+   :maxdepth: 1
+   
+   specifications
+   /aibs/compliance
 
 Accessories
 -----------
@@ -23,3 +28,10 @@ Accessories
 
    warp100
    ack
+
+
+
+
+
+
+


### PR DESCRIPTION
Re: my convo with Josh on last commit.
Edited the link formats on BH and WH card "main menu" pages (aka "index.rst"). Previous links on those pages were static, now they are relative and employ toctrees. Also changed font formatting error on the aibs/compliance page, so it is consistent with other pages.