### PR TITLE
Fix broken tt-forge-fe link, replace with tt-forge-onnx

### DIFF
--- a/core/forge/forge-frontend-compiler/index.rst
+++ b/core/forge/forge-frontend-compiler/index.rst
@@ -4,7 +4,7 @@ TT-Forge offers three different frontend compilers, making it easy to work with 
 
 * TT-Torch - for models using PyTorch
 * TT-XLA - for models using something from the XLA ecosystem like JAX or TensorFlow
-* TT-Forge-FE - a general-purpose compiler that's framework-agnostic and able to support multiple input formats (ONNX, TorchScript, custom graph format)
+* TT-Forge-ONNX - a general-purpose compiler that's framework-agnostic and able to support multiple input formats (ONNX, TorchScript, custom graph format)
 
 .. toctree::
    :caption: TT-Forge Frontend Compiler
@@ -12,5 +12,5 @@ TT-Forge offers three different frontend compilers, making it easy to work with 
 
    
     TT-Torch <https://docs.tenstorrent.com/tt-torch/>
-    TT-Forge-FE <https://docs.tenstorrent.com/tt-forge-fe/>
+    TT-Forge-ONNX <https://docs.tenstorrent.com/tt-forge-onnx/>
     TT-XLA <https://docs.tenstorrent.com/tt-xla/>

--- a/core/forge/index.rst
+++ b/core/forge/index.rst
@@ -1,7 +1,7 @@
 TT-Forge
 =======================================
 TT-Forge is the name of Tenstorrent's end-to-end compiler stack. It consists of: 
-   * Frontends - TT-Torch, TT-XLA, TT-Forge-FE
+   * Frontends - TT-Torch, TT-XLA, TT-Forge-ONNX
    * Middle/backend compiler - TT-MLIR 
    * Extensive cookbook for LLM and other model fine-tuning and training experiments on TT devices - TT-Blacksmith
 


### PR DESCRIPTION
- Replaces broken link `https://docs.tenstorrent.com/tt-forge-fe/` with `https://docs.tenstorrent.com/tt-forge-onnx/` in the TT-Forge frontend compiler docs
- Updates display name from TT-Forge-FE to TT-Forge-ONNX