### PR TITLE
Adding Open Source AI Model Terms 

### DIFF
--- a/core/os-model-terms.md
+++ b/core/os-model-terms.md
@@ -1,0 +1,13 @@
+# OS Model Terms
+
+## Welcome to TT-QuietBox 2 (Blackhole)!
+To get you up and running as quickly as possible, your machine may have come pre-installed with some open-weight AI models: [Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B), [Whisper-large-v3](https://huggingface.co/openai/whisper-large-v3), [SpeechT5-TTS](https://huggingface.co/microsoft/speecht5_tts), and [Wan2.2-T2V-A14B-Diffusers](https://huggingface.co/Wan-AI/Wan2.2-T2V-A14B-Diffusers).
+
+A Quick Note on Usage: To keep things transparent, please acknowledge the following before you begin:
+1. **Demonstration Only**: These models are provided to showcase Tenstorrent hardware. We are the hardware vendor, not the model developers.
+1. **No Warranty**: We provide these models "as-is" without any specific guarantees. Since AI outputs can be unpredictable or incorrect, please use them responsibly.
+1. **Liability**: Tenstorrent and the original model creators aren't responsible for any direct or indirect damages arising from your use of this software.
+1. **Compliance**: Your use must align with each model's specific license and Acceptable Use Policy. See links above.
+1. **Ownership**: You take full responsibility for the content you generate and agree to hold Tenstorrent harmless from any claims related to your use of the system.
+
+Any questions? Reach out on [Discord](https://discord.gg/tvhGzHQwaj). 


### PR DESCRIPTION
Adding a deep-linkable page for our open-source model terms around pre-loaded models for the QB2.