### PR TITLE
Small QB2 Docs Update (acoustics, link to DevHub, registered TM for BH)

### DIFF
--- a/core/systems/quietbox/quietbox-bh-2/setup.md
+++ b/core/systems/quietbox/quietbox-bh-2/setup.md
@@ -15,7 +15,7 @@ myst:
 
 *<span style="color: purple;">Note: This product is pre-launch and documentation is subject to change.</span>*
 
-This guide shows users how to safely unbox, setup hardware, and install software on a TT-QuietBox 2 (Blackhole) Workstation.
+This guide shows users how to safely unbox, setup hardware, and install software on a TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) Workstation.
 
 ## Before You Begin
 
@@ -103,7 +103,7 @@ Note: Only use certified HDMI cables with the TT-QuietBox 2. Using non-certified
 
 2. **Connect peripherals.** Connect the HDMI monitor, keyboard, and mouse to the back of the Workstation. (Please note: video is not supported through the USB-C port). For internet connections, we recommend Ethernet over WiFi for faster downloading of models. If you prefer Ethernet, connect your Ethernet cable to the RJ45 port. 
 
-For sound and interaction with future text-to-speech (TTS) and speech-to-text (STT) AI models, there are a few options. You may either connect the provided speakerphone to the USB-C port or connect an audio device to the audiojack. 
+For sound and interaction with future text-to-speech (TTS) and speech-to-text (STT) AI models, there are a few options. You may either connect the provided speakerphone to the USB-C port or connect your own audio device to the audiojack. 
 
 3. **Power on the Workstation.** On the back of the workstation, flip the switch on the PSU to the "I" position.  
 
@@ -178,13 +178,7 @@ If `.tenstorrent-venv` is not active, or you don’t see all four accelerators l
 
 TT-QuietBox 2 comes pre-installed with TT-Studio, Tenstorrent's simple web interface for running AI models.
 
-TT-Studio currently supports the following common models on TT-QuietBox 2:
-
-| Type | Model |
-| --- | --- |
-| Video Gen | Wan 2.2 (coming soon) |
-| Text to Image | Flux (coming soon) |
-| Language Models | GPT-OSS 120B (coming soon), Llama 3.1 70B, Qwen3-32B, Llama 3.1 8B |
+For the most up-to-date list of models supported by TT-QuietBox 2, check the [Developer Hub](https://tenstorrent.com/developers).
 
 To deploy a model in TT-Studio, first download the model weights from Hugging Face. 
 

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -12,9 +12,9 @@ myst:
 
 # Specifications
 
-*<span style="color: purple;">Note: This content is still being drafted. Once finalized, the complete documentation will be available at docs.tenstorrent.com</span>*
+*<span style="color: purple;">Note: This product is pre-launch and documentation is subject to change.</span>*
 
-This document provides detailed technical specifications for the TT-QuietBox™ 2 (Blackhole™) Liquid-Cooled Desktop Workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
+This document provides detailed technical specifications for the TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) Workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
 
 ## **Package Contents**
 
@@ -38,10 +38,14 @@ The Tenstorrent TT-QuietBox 2 (Blackhole) system package includes the following 
 | External I/O Ports | 1x HDMI Port<br />1x USB 3.2 Gen 2 Type-A Port<br />1x USB 3.2 Gen 2 Type-C Port (non-video)<br />2x USB 3.2 Gen 1 Ports<br />4x USB 2.0 Ports<br />1 x BIOS Flashback Button<br />HD Audio Jacks: Line in / Front Speaker / Microphone |
 | Connectivity | 1 x RJ45 LAN Port<br /><ul class="tt-spec-cell-list"><li>Gigabit LAN 10/100/1000 Mb/s Base T</li><li>Realtek 8111H</li></ul><br />2x WiFi Antenna<br /><ul class="tt-spec-cell-list"><li>802.11ax WiFi 6 Module</li><li>Supports IEEE 802.11a/b/g/n/ax</li><li>Supports Dual-Band (2.4/5 GHz)</li><li>Supports Bluetooth 5.3</li></ul> |
 | Power Supply | 1600W Cooler Master V Platinum 1600 V2 |
+| Sound Pressure | 38 dBA (under max operating load) |
 | System Dimensions | Height: 15.6” (39.5 cm) Width: 9.1” (23.1 cm) Depth: 17.8” (45.2 cm) (including handles and feet) |
 | System Weight | 20 kg (44 lbs) +/- 1.5 lbs   |
 | Shipping Box Dimensions | Height: 20.7” (52.5 cm) Width: 14.4” (36.7 cm) Depth: 25.0” (63.5 cm) |
 | Shipping Box Weight | 23.2 kg (52 lbs)  |
+
+## **Supported Models**
+For the most up-to-date list of models supported by TT-QuietBox 2, check the [Developer Hub](https://tenstorrent.com/developers).
 
 ## **Power and Operating Conditions**
 


### PR DESCRIPTION
added acoustics to spec table + link to supported models in DevHub + added registered trademark symbol to first mention of "Blackhole" (in the QB2 documentation only. We'll have to do a broader update soon)