### PR TITLE
Add TT-Lang to Software sidebar

### DIFF
--- a/core/index.rst
+++ b/core/index.rst
@@ -29,6 +29,7 @@ Tenstorrent
 
    forge/index
    TT-Metalium <https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/index.html>
+   TT-Lang <https://docs.tenstorrent.com/tt-lang/>
    TT-NN <https://docs.tenstorrent.com/tt-metal/latest/ttnn/index.html>
    Manual Software Installation <getting-started/manual-software-install>
    tools/index


### PR DESCRIPTION
## Summary

Adds a link to [TT-Lang documentation](https://docs.tenstorrent.com/tt-lang/) in the **Software** sidebar, between TT-Metalium and TT-NN.

## Test plan

- [x] Build or preview docs locally and confirm **Software** sidebar shows: TT-Metalium → TT-Lang → TT-NN
- [x] Verify the TT-Lang link resolves to https://docs.tenstorrent.com/tt-lang/