### PR TITLE
Added trademark symbols to product titles on home page

### DIFF
--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -121,6 +121,15 @@
       margin-bottom: 1rem;
     }
 
+    .card .reg {
+      font-size: 0.70em;
+      vertical-align: super;
+      line-height: 0;
+      margin-left: -0.3em;
+      position: relative;
+      top: -0.3em;
+    }
+
     .small-card h4 {
       font-weight: normal;
       font-size: 16px;
@@ -235,8 +244,8 @@
       <h2>Cards</h2>
       <div class="grid">
         <a href="aibs/blackhole/index.html" class="card">
-          <img src="_static/home/blackhole.png" alt="Blackhole™" />
-          <h3>Blackhole™</h3>
+          <img src="_static/home/blackhole.png" alt="Blackhole" />
+          <h3>Blackhole<span class="reg">®</span></h3>
         </a>
         <a href="aibs/wormhole/index.html" class="card">
           <img src="_static/home/wormhole.png" alt="Wormhole™" />
@@ -250,11 +259,11 @@
       <div class="grid">
         <a href="systems/index.html" class="card">
           <img src="_static/home/tt-quietbox.png" alt="TT-QuietBox" />
-          <h3>TT-QuietBox</h3>
+          <h3>TT-QuietBox™</h3>
         </a>
         <a href="systems/t3000/index.html" class="card">
           <img src="_static/home/tt-loudbox.png" alt="TT-LoudBox" />
-          <h3>TT-LoudBox</h3>
+          <h3>TT-LoudBox™</h3>
         </a>
       </div>
     </div>
@@ -268,7 +277,7 @@
           class="card small-card"
         >
           <img src="_static/home/tt-nn.png" alt="TT-NN" />
-          <h4>TT-NN</h4>
+          <h4>TT-NN™</h4>
         </a>
         <a
           target="_blank"


### PR DESCRIPTION
on the home page: all products with trademarks now have that symbol visually showing in their titles (before, only half had them; this is an edit for consistency). This change was prompted by Legal.