### PR TITLE
P300 spec page

### DIFF
--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -20,7 +20,7 @@ This document provides technical specifications for the Tenstorrent Blackhole® 
 
 The p300c card features Tenstorrent’s high performance Blackhole Tensix Processor, with 240 Tensix Cores and 64 GB of GDDR6, operating at up to 600W in an active-cooled form factor geared for desktop workstations. Eaach card includes four passive QSFP-DD 800G ports, enabling multiple cards linking together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
 
-## Blackhole™ Tensix Processor Overview
+## Blackhole Tensix Processor Overview
 
 The Tenstorrent Blackhole™ Tensix Processor powers the Blackhole™ p300c card. The processor features:
 

--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -1,0 +1,93 @@
+---
+myst:
+  html_meta:
+    product-name: Blackhole™ Tensix Processor, Blackhole™ p300, Tenstorrent
+    technology-concepts: PCIe, ATX, ESD, RISC-V, GDDR6, Floating point, Block floating point, Integer, TensorFloat, Vector
+    document-type: Reference
+---
+
+```{eval-rst}
+:orphan:
+```
+
+# Blackhole p300c Card — Specifications and Requirements (Draft)
+
+:::{admonition} Draft
+This page is a work in progress for the Blackhole p300c card. This page is not linked from the site navigation.
+:::
+
+This document provides technical specifications for the Tenstorrent Blackhole® p300c card. This Blackhole card powers the TT-QuietBox 2 workstation, and is not sold seperately.
+
+The p300c card features Tenstorrent’s high performance Blackhole Tensix Processor, with 240 Tensix Cores and 64 GB of GDDR6, operating at up to 600W in an active-cooled form factor geared for desktop workstations. Eaach card includes four passive QSFP-DD 800G ports, enabling multiple cards linking together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
+
+## Blackhole™ Tensix Processor Overview
+
+The Tenstorrent Blackhole™ Tensix Processor powers the Blackhole™ p300c card. The processor features:
+
+* Tensix core count: 240  
+* SiFive x280 "Big RISC-V" cores: 32 TBD
+* SRAM: 360 MB (1.5 MB per Tensix core)  TBD
+* Memory: up to 64 GB GDDR6 with a 2x 256-bit memory bus 
+
+
+## Card Specifications
+
+:::{note}
+Cooling, form factor, and deployment guidance for p300 are **TBD**. See the {doc}`p150a/p150b specifications <specifications>` for comparable Blackhole™ PCIe card families.
+:::
+
+| Specification             | p300 (draft)                |
+| ------------------------- | --------------------------- |
+| Part Number               | TC-03007                    |
+| Tensix Cores              | 240                         |
+| AI Clock                  | TBD                         |
+| "Big RISC-V" Cores        | 32 TBD                      |
+| SRAM                      | 360 MB                      |
+| Memory                    | 64GB GDDR6                  |
+| Memory Speed              | 16 GT/sec                   |
+| Memory Bandwidth          | 1024 GB/sec                 |
+| TeraFLOPS (BLOCKFP8)      | 1327                         |
+| TBP (Total Board Power)   | 600W                         |
+| External Power            | TBD                         |
+| Connectivity              | TBD                         |
+| System Interface          | PCI Express 5.0 x16         |
+| Cooling                   | Liquid                         |
+| Dimensions (WxDxH)        | 21.66mm x 307mm x 112.65mm                        |
+
+**For connecting to Tenstorrent Blackhole-based cards only.* *(confirm for p300)*
+
+
+## Connectivity
+
+Blackhole™ p300 QSFP-DD port count, data rate, and cable requirements: **TBD**.
+
+<!-- Placeholder: reuse p150 connectivity diagram until p300 port layout is published
+![](./images/bh_portspec.png)
+-->
+
+
+## Supported Data Precision Formats
+
+The Blackhole™ Tensix Processor supports the following data precision formats:
+
+| Format               | Bit Depth (Tensix Cores)                    | Bit Depth (Big RISC-V Cores)    |
+| -------------------- | ------------------------------------------- | ------------------------------- |
+| Floating point       | FP8, FP16, BFLOAT16<br />FP32 (Output Only) | FP8, FP16, BFLOAT16, FP32, FP64 |
+| Block floating point | BLOCKFP2, BLOCKFP4, BLOCKFP8                | -                               |
+| Integer              | INT8<br />INT32 (Output Only)               | INT8, INT16, INT32, INT64       |
+| Unsigned Integer     | UINT8                                       | -                               |
+| TensorFloat          | TF32                                        | -                               |
+| Vector               | VTF19, VFP32                                | VFP64                           |
+
+
+
+## Environment Specifications
+
+The Blackhole™ p300 card is designed to meet these environmental specifications *(confirm against final product data)*:
+
+| Specification               | Requirement               |
+| --------------------------- | ------------------------- |
+| Operating Temperature Range | 10°C/50°F - 35°C/95°F     |
+| Storage Temperature Range   | -40°C/-40°F - 75°C/167°F  |
+| Elevation                   | -5 ft. to 10,000 ft.      |
+| Air Flow                    | TBD                       |

--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -10,84 +10,33 @@ myst:
 :orphan:
 ```
 
-# Blackhole p300c Card — Specifications and Requirements (Draft)
+# Blackhole p300c Card — Specifications and Requirements
 
-:::{admonition} Draft
-This page is a work in progress for the Blackhole p300c card. This page is not linked from the site navigation.
+:::{admonition} Note
+The Blackhole<sup>®</sup> p300c card powers the TT-QuietBox 2 workstation, and is not sold seperately. This page is for reference only. To add a Blackhole card to your exsiting sysem, see the {doc}`p150a/p150b specifications <specifications>` for comparable Blackhole™ PCIe card families.
 :::
 
-This document provides technical specifications for the Tenstorrent Blackhole® p300c card. This Blackhole card powers the TT-QuietBox 2 workstation, and is not sold seperately.
-
-The p300c card features Tenstorrent’s high performance Blackhole Tensix Processor, with 240 Tensix Cores and 64 GB of GDDR6, operating at up to 600W in an active-cooled form factor geared for desktop workstations. Eaach card includes four passive QSFP-DD 800G ports, enabling multiple cards linking together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
+This document provides technical specifications for the Tenstorrent Blackhole p300c card. 
 
 ## Blackhole Tensix Processor Overview
 
-The Tenstorrent Blackhole™ Tensix Processor powers the Blackhole™ p300c card. The processor features:
-
-* Tensix core count: 240  
-* SiFive x280 "Big RISC-V" cores: 32 TBD
-* SRAM: 360 MB (1.5 MB per Tensix core)  TBD
-* Memory: up to 64 GB GDDR6 with a 2x 256-bit memory bus 
-
+The p300c card features two of Tenstorrent’s high performance Blackhole ASICs, each containing 120 Tensix Cores and 32 GB of GDDR6. The card includes four passive QSFP-DD 800G ports, enabling multiple cards linking together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
 
 ## Card Specifications
 
-:::{note}
-Cooling, form factor, and deployment guidance for p300 are **TBD**. See the {doc}`p150a/p150b specifications <specifications>` for comparable Blackhole™ PCIe card families.
-:::
-
-| Specification             | p300 (draft)                |
+| Specification             | p300c             |
 | ------------------------- | --------------------------- |
 | Part Number               | TC-03007                    |
 | Tensix Cores              | 240                         |
 | AI Clock                  | TBD                         |
 | "Big RISC-V" Cores        | 32 TBD                      |
-| SRAM                      | 360 MB                      |
+| SRAM                      | 360 MB (1.5 MB per Tensix core)                     |
 | Memory                    | 64GB GDDR6                  |
 | Memory Speed              | 16 GT/sec                   |
 | Memory Bandwidth          | 1024 GB/sec                 |
-| TeraFLOPS (BLOCKFP8)      | 1327                         |
 | TBP (Total Board Power)   | 600W                         |
 | External Power            | TBD                         |
 | Connectivity              | TBD                         |
-| System Interface          | PCI Express 5.0 x16         |
 | Cooling                   | Liquid                         |
 | Dimensions (WxDxH)        | 21.66mm x 307mm x 112.65mm                        |
 
-**For connecting to Tenstorrent Blackhole-based cards only.* *(confirm for p300)*
-
-
-## Connectivity
-
-Blackhole™ p300 QSFP-DD port count, data rate, and cable requirements: **TBD**.
-
-<!-- Placeholder: reuse p150 connectivity diagram until p300 port layout is published
-![](./images/bh_portspec.png)
--->
-
-
-## Supported Data Precision Formats
-
-The Blackhole™ Tensix Processor supports the following data precision formats:
-
-| Format               | Bit Depth (Tensix Cores)                    | Bit Depth (Big RISC-V Cores)    |
-| -------------------- | ------------------------------------------- | ------------------------------- |
-| Floating point       | FP8, FP16, BFLOAT16<br />FP32 (Output Only) | FP8, FP16, BFLOAT16, FP32, FP64 |
-| Block floating point | BLOCKFP2, BLOCKFP4, BLOCKFP8                | -                               |
-| Integer              | INT8<br />INT32 (Output Only)               | INT8, INT16, INT32, INT64       |
-| Unsigned Integer     | UINT8                                       | -                               |
-| TensorFloat          | TF32                                        | -                               |
-| Vector               | VTF19, VFP32                                | VFP64                           |
-
-
-
-## Environment Specifications
-
-The Blackhole™ p300 card is designed to meet these environmental specifications *(confirm against final product data)*:
-
-| Specification               | Requirement               |
-| --------------------------- | ------------------------- |
-| Operating Temperature Range | 10°C/50°F - 35°C/95°F     |
-| Storage Temperature Range   | -40°C/-40°F - 75°C/167°F  |
-| Elevation                   | -5 ft. to 10,000 ft.      |
-| Air Flow                    | TBD                       |

--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    product-name: Blackhole™ Tensix Processor, Blackhole™ p300, Tenstorrent
+    product-name: Blackhole™ Tensix Processor, Blackhole™ p300c, Tenstorrent
     technology-concepts: PCIe, ATX, ESD, RISC-V, GDDR6, Floating point, Block floating point, Integer, TensorFloat, Vector
     document-type: Reference
 ---
@@ -13,14 +13,14 @@ myst:
 # Blackhole p300c Card — Specifications and Requirements
 
 :::{admonition} Note
-The Blackhole<sup>®</sup> p300c card powers the TT-QuietBox 2 workstation, and is not sold seperately. This page is for reference only. To add a Blackhole card to your exsiting sysem, see the {doc}`p150a/p150b specifications <specifications>` for comparable Blackhole™ PCIe card families.
+The Blackhole<sup>®</sup> p300c card powers the TT-QuietBox 2 workstation, and is not sold separately. This page is for reference only. To add a Blackhole card to your existing sysem, see the {doc}`p150a/p150b specifications <specifications>` for comparable Blackhole™ PCIe card families.
 :::
 
-This document provides technical specifications for the Tenstorrent Blackhole p300c card. 
+This document provides technical specifications for the Tenstorrent Blackhole p300c card.
 
 ## Blackhole Tensix Processor Overview
 
-The p300c card features two of Tenstorrent’s high performance Blackhole ASICs, each containing 120 Tensix Cores and 32 GB of GDDR6. The card includes four passive QSFP-DD 800G ports, enabling multiple cards linking together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
+The p300c card features two of Tenstorrent’s high performance Blackhole ASICs, each containing 120 Tensix Cores and 32 GB of GDDR6. The card includes four passive QSFP-DD 800G ports, enabling multiple cards linked together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
 
 ## Card Specifications
 

--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -13,10 +13,10 @@ myst:
 # Blackhole p300c Card — Specifications and Requirements
 
 :::{admonition} Note
-The Blackhole<sup>®</sup> p300c card powers the TT-QuietBox 2 workstation, and is not sold separately. This page is for reference only. To add a Blackhole card to your existing sysem, see the {doc}`p150a/p150b specifications <specifications>` for comparable Blackhole™ PCIe card families.
+The Blackhole<sup>®</sup> p300c card powers the TT-QuietBox 2 workstation, and is not sold separately. This page is for reference only. If you are interested in a Blackhole card to add to your existing system, see the availabe cards at [Tenstorrent.com](https://tenstorrent.com/hardware/cards).
 :::
 
-This document provides technical specifications for the Tenstorrent Blackhole p300c card.
+This document provides technical specifications for the Tenstorrent Blackhole p300c card inside of the TT-QuietBox 2.
 
 ## Blackhole Tensix Processor Overview
 
@@ -28,15 +28,13 @@ The p300c card features two of Tenstorrent’s high performance Blackhole ASICs,
 | ------------------------- | --------------------------- |
 | Part Number               | TC-03007                    |
 | Tensix Cores              | 240                         |
-| AI Clock                  | TBD                         |
+| AI Clock                  | 1.35 GHz                        |
 | "Big RISC-V" Cores        | 32 TBD                      |
 | SRAM                      | 360 MB (1.5 MB per Tensix core)                     |
 | Memory                    | 64GB GDDR6                  |
 | Memory Speed              | 16 GT/sec                   |
 | Memory Bandwidth          | 1024 GB/sec                 |
 | TBP (Total Board Power)   | 600W                         |
-| External Power            | TBD                         |
-| Connectivity              | TBD                         |
 | Cooling                   | Liquid                         |
 | Dimensions (WxDxH)        | 21.66mm x 307mm x 112.65mm                        |
 

--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -20,9 +20,9 @@ This document provides technical specifications for the Tenstorrent Blackhole p3
 
 ## Blackhole Tensix Processor Overview
 
-The p300c card features two of Tenstorrent’s high performance Blackhole ASICs, each containing 120 Tensix Cores and 32 GB of GDDR6. The card includes four passive QSFP-DD 800G ports, enabling multiple cards linked together to pool memory and improve performance. The p300c card is supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal.
+The p300c card features two of Tenstorrent’s high performance Blackhole ASICs, which each contain 120 Tensix Cores and 32 GB of GDDR6. The cards are supported by Tenstorrent’s fully open source software stack, granting developers full access to the metal. Inside the TT-QuietBox 2, two p300c cards connect internally with a Samtec ARP6 series High Performance cable, enabling pooled memory and improved performance.
 
-## Card Specifications
+## Full Card Specifications
 
 | Specification             | p300c             |
 | ------------------------- | --------------------------- |

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -94,7 +94,7 @@ The Power Supply Unit (PSU) on the TT-QuietBox 2 is rated to draw up to 1600W of
 
 ## **Internal Topology**
 
-The TT-QuietBox 2 is enabled by two Tenstorrent Blackhole cards, which are connected internally with a Samtec ARP6 series High Performance cable. The below topology is pre-installed by Tenstorrent, and is here for your reference.
+The TT-QuietBox 2 is enabled by two Tenstorrent {doc}`Blackhole p300c cards </aibs/blackhole/p300>`, which are connected internally with a Samtec ARP6 series High Performance cable. The below topology is pre-installed by Tenstorrent, and is here for your reference. 
 
 ```{figure} ./qb2-topology.jpg
 :width: 65%


### PR DESCRIPTION
This page is created by request of Kaitlyn and our QB2 beta testers. 

Apparently, most AIs don't believe the p300c exists, since we have no documentation for it.

This page contextualizes the p300c as an internal component of the QB2 -- not sold separately.

This page is deliberately left off the main left menu. Right now, we want it to be live on the docs site, but only accessed with a specific link and to be searchable by AI tools.

We may change this page based on user feedback.