### PR TITLE
docs(getting-started): add TT-QuietBox 2 setup note to Before You Begin

### DIFF
--- a/core/getting-started/README.md
+++ b/core/getting-started/README.md
@@ -12,6 +12,10 @@ This guide assists users who have completed the physical hardware setup of their
 
 ## **Before You Begin**
 
+:::{note}
+Setting up your new TT-QuietBox® 2? Follow the [Setup Guide](../systems/quietbox/quietbox-bh-2/setup.md).
+:::
+
 Before you begin the software installation, ensure your host machine meets the following prerequisites:
 
 * The host machine has an internet connection to download software packages.  


### PR DESCRIPTION
## Summary

Adds a `note` admonition at the top of the **Before You Begin** section in the getting-started software install guide, directing new TT-QuietBox® 2 owners to the QB2 setup guide:

> Setting up your new TT-QuietBox® 2? Follow the [Setup Guide](../systems/quietbox/quietbox-bh-2/setup.md).

## Notes
- Edited the MyST source (`core/getting-started/README.md`); the `.html` is build output.
- Used a relative `.md` link matching the doc's existing cross-reference style, so MyST resolves it to `setup.html` as a validated internal reference (not a hardcoded path).

## Verification
- Clean Sphinx build with no warnings for `getting-started/README` or the new link.
- Verified rendered HTML: link resolves to `../systems/quietbox/quietbox-bh-2/setup.html` (`class="reference internal"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)