### PR TITLE
Pin tt-installer SW versions in QB2 add-new-user command

### DIFF
--- a/core/systems/quietbox/quietbox-bh-2/support-bh-2.md
+++ b/core/systems/quietbox/quietbox-bh-2/support-bh-2.md
@@ -129,7 +129,14 @@ curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/
 
 chmod +x install.sh
 
-./install.sh --mode-non-interactive --install-container-runtime=no
+./install.sh \
+  --kmd-version=2.8.0 \
+  --smi-version=5.2.0 \
+  --flash-version=3.8.0 \
+  --fw-version=19.10.0 \
+  --metalium-image-tag=v0.72.0 \
+  --mode-non-interactive \
+  --install-container-runtime=no
 ```
 5. Upon reboot, log in with the new user, open a Terminal window, and run these commands:
 


### PR DESCRIPTION
## Summary

> **⚠️ TEMPORARY UPDATE** — this pins specific software versions only until tt-installer is updated to pull the latest golden SW versions automatically. Once that lands, this command will be reverted by @hous to the unpinned form.

Updates the `tt-installer` command in the QB2 "How Do I Add a New User" section (`core/systems/quietbox/quietbox-bh-2/support-bh-2.md`) to pin the golden SW versions:

- `--kmd-version=2.8.0`
- `--smi-version=5.2.0`
- `--flash-version=3.8.0`
- `--fw-version=19.10.0`
- `--metalium-image-tag=v0.72.0`

## Testing

Verified locally with the sphinx_autobuild preview — the updated command renders correctly on the QB2 support page.

Verified the SW/FW versions worked correctly on my QB2.