### PR TITLE
Add Blackhole/Wormhole FAQ updates and install guide references

### DIFF
--- a/core/aibs/blackhole/installation.md
+++ b/core/aibs/blackhole/installation.md
@@ -24,6 +24,10 @@ Before you begin the installation process, complete the following steps:
      An **ATX 3.1 Certified power supply** or better is required. Using an older or inadequate power supply may result in system instability.  
      :::
    * One (1) **12+4-pin 12V-2x6 power connector**.  
+     :::{note}
+     If your PSU does not have this connector available, see the [FAQ and Troubleshooting guide](./support.md) to determine which adapter to use.
+     :::
+
 3. Discharge static electricity from your body by wearing an **ESD wrist strap** (*recommended*) or by touching a grounded surface before touching system components or the add-in board.
 
 ## Desktop Workstation Installation (p100a/p150a)

--- a/core/aibs/blackhole/support.md
+++ b/core/aibs/blackhole/support.md
@@ -3,10 +3,10 @@ myst:
   html_meta:
     product-name: Blackhole™ AI Processor
     technology-concepts: PCIe, QSFP-DD, active cooling, passive cooling, GDDR6, ASIC, firmware
-    document-type: Troubleshooting
+    document-type: FAQ and Troubleshooting
 ---
 
-# Troubleshooting Common Hardware Issues
+# FAQ and Troubleshooting
 This document assists Tenstorrent users in resolving common issues encountered with Blackhole™ AI Processors. It provides solutions and directs users to appropriate support resources.
 
 ## **How do I choose between the Tenstorrent Blackhole™ p100a/p150a/p150b?**
@@ -15,14 +15,27 @@ This document assists Tenstorrent users in resolving common issues encountered w
 - **p150a:** This card provides additional local memory (32 GB) compared to p100a and slightly higher compute density. It also features four passive 800 Gbps QSFP-DD ports used for networking with other Tenstorrent Blackhole™ p150a/p150b cards.  It features an **active cooling solution** that conforms to industry PCI specifications, and is intended for **single- or multi-card operation** in **conventional desktop systems**.
 - **p150b:** This card features identical specifications to p150a, but features a **passive cooling solution** that conforms to industry PCI specifications, and is intended for **single- or multi-card operation** in **rack-mounted servers** with **existing high static pressure, forced air cooling**.
 
+## **What PSU and Connector should I use to connect my Blackhole card?**
+
+Tenstorrent Blackhole cards use a 12V-2x6 (12+4-pin) power connector and are designed for use with ATX 3.1-certified or newer Power Supply Units (PSUs). Native PSU support via a 12V-2x6 connector is the recommended configuration.
+
+Never use an ATX 2.0 or older PSU.
+
+## **My PSU doesn't have a 12V-2x6 (12+4-pin) power connector available. What adapter should I get for my Blackhole card?**
+
+If a native 12V-2x6 connector is not available, Blackhole cards may be powered using a PSU-manufacturer-approved adapter that combines standard 8-pin PCIe and/or EPS 4+4-pin connectors, provided the combined power delivery meets the card's total power requirements and the PSU is ATX 3.1 certified or better. Each input cable must be connected to a separate PSU output.
+
+The Blackhole cards require 300W of power to function. Ensure that the combination of PSU outputs meets this requirement, and that the total load on your PSU does not exceed the total PSU output power.
+
+To ensure electrical compatibility and prevent hardware damage, only power cables and adapters supplied or explicitly approved by the PSU manufacturer should be used. Many PSU manufacturers key the connectors so that only their power connector works. The power connector must be fully seated, and tight bends near the connector should be avoided.
+
+Use of older 12VHPWR cables is not recommended, even though they are physically compatible with the 12V-2x6 connector. The 12V-2x6 standard replaced 12VHPWR to reduce the risk of overheating (and melting) associated with improper connector seating.
+
 ## **Which QSFP cable(s) should I purchase for my Tenstorrent Blackhole™ cards?**
 
-We plan to offer internally validated QSFP cables for sale in the future, but in the meantime, the following models have been validated for use with your Blackhole™ cards:
+For standard short-reach setups, validated 0.5m QSFP cables are available directly on the Tenstorrent store [hardware cards page](https://tenstorrent.com/hardware/cards).
 
-- [Amphenol 0.5m (1.6 ft.) 800G Passive QSFP-DD (SF-NJYYER0006-000.5M)](https://cablesondemand.com/amphenol-sf-njyyer0006-000-5m-0-5m-1-6-800g-qsfp-dd-112g-cable-800-gigabit-ethernet-passive-direct-attach-qsfp-double-density-112g-cable-dual-entry-32-awg-qsfp-dd-112g-to-qsfp-dd-112g-sf-njyyer0006-000-5m)
-- [Amphenol 1m (3.3 ft.) 800G Passive QSFP-DD (SF-NJYYEK0001-001M)](https://cablesondemand.com/qsfp-dd-direct-attach-cables-200g-400g-800g-dac-1/amphenol-sf-njyyek0001-001m-1m-3-3-800g-qsfp-dd-112g-cable-800-gigabit-ethernet-passive-direct-attach-qsfp-double-density-112g-cable-dual-entry-32-awg-qsfp-dd-112g-to-qsfp-dd-112g-sf-njyyek0001-001m)
-- [FS 0.5m (2 ft.) 800G Passive QSFP-DD (QDD-800G-PC005)](https://www.fs.com/products/154258.html?attribute=36925&id=3871095)
-- [FS 1m (3 ft.) 800G Passive QSFP-DD (QDD-800G-PC01)](https://www.fs.com/products/154259.html?attribute=36923&id=3720628)
+If you need 1m cables, we recommend either [Amphenol 1m (3.3 ft.) 800G Passive QSFP-DD (SF-NJYYEK0001-001M)](https://cablesondemand.com/qsfp-dd-direct-attach-cables-200g-400g-800g-dac-1/amphenol-sf-njyyek0001-001m-1m-3-3-800g-qsfp-dd-112g-cable-800-gigabit-ethernet-passive-direct-attach-qsfp-double-density-112g-cable-dual-entry-32-awg-qsfp-dd-112g-to-qsfp-dd-112g-sf-njyyek0001-001m) or [FS 1m (3 ft.) 800G Passive QSFP-DD (QDD-800G-PC01)](https://www.fs.com/products/154259.html?attribute=36923&id=3720628).
 
 ## **The idle power consumption of my Tenstorrent Blackhole™ card seems high**
 

--- a/core/aibs/wormhole/README.md
+++ b/core/aibs/wormhole/README.md
@@ -5,4 +5,5 @@ This section outlines the system requirements, physical installation instruction
 - [Specifications/Requirements](./specifications.md)
 - [Hardware Installation](./installation.md)
 - [Software Setup](https://docs.tenstorrent.com/getting-started/README.html)
+- [FAQ and Troubleshooting](./support.md)
 - [Regulatory Compliance](../compliance.md)

--- a/core/aibs/wormhole/index.rst
+++ b/core/aibs/wormhole/index.rst
@@ -18,6 +18,7 @@ Reference Materials
    :maxdepth: 1
    
    specifications
+   support
    /aibs/compliance
 
 Accessories

--- a/core/aibs/wormhole/installation.md
+++ b/core/aibs/wormhole/installation.md
@@ -18,6 +18,10 @@ Follow these instructions to install your Tenstorrent Wormhole™ n150d/n150s/n3
       2. The n150s and n300s are dual-slot width cards and will require the adjacent expansion slot to be vacant if you're using the Active Cooling Kit.
       3. The n150d and n300d are 2.5-slot width cards with axial fan coolers. Please ensure your chassis has sufficient airflow to exhaust the heat from these cards.
    2. One (1) **EPS12V 4+4-pin power connector**
+      :::{note}
+      If your PSU does not have this connector available, see the [FAQ and Troubleshooting guide](./support.md) to determine which adapter to use.
+      :::
+
 3. Discharge your body's static electricity by wearing an **ESD wrist strap** *(recommended)* or touching a grounded surface before touching system components or the add-in card.
 
 ## Desktop Workstation Installation

--- a/core/aibs/wormhole/support.md
+++ b/core/aibs/wormhole/support.md
@@ -1,0 +1,26 @@
+---
+myst:
+  html_meta:
+    product-name: Wormhole™ AI Processor
+    technology-concepts: PCIe, active cooling, passive cooling, GDDR6, ASIC, firmware
+    document-type: FAQ and Troubleshooting
+---
+
+# FAQ and Troubleshooting
+This document assists Tenstorrent users in resolving common issues encountered with Wormhole™ AI Processors. It provides solutions and directs users to appropriate support resources.
+
+## **What PSU and Connector should I use to connect my Wormhole card?**
+
+Tenstorrent Wormhole cards use 4+4-pin EPS12V power connectors and are designed for use with ATX 3.0 and 3.1-compliant Power Supply Units (PSUs) capable of supplying sufficient total power for the card and system configuration. Native PSU support via a 4+4-pin EPS12V connector is the recommended configuration.
+
+## **My PSU doesn't have an EPS12V power connector available. What adapter should I get for my Wormhole card?**
+
+If a native EPS12V connector is not available, the card may be powered using a PSU-manufacturer-approved adapter, including PCIe 6+2-pin to EPS12V adapters, provided the combined power delivery meets the card's total power requirements. Each input cable must be connected to a separate PSU output.
+
+Many PSU manufacturers use proprietary power cable kits to prevent incorrect connections. 8-pin EPS12V and 8-pin PCIe power connectors are not interchangeable and must not be substituted for one another, as they use different grounding and pin assignments.
+
+The Wormhole cards require 160W (n150)/300W (n300) of power to function. Ensure that the combination of PSU outputs meets this requirement, and that the total load on your PSU does not exceed the total PSU output power.
+
+Do not use 12VHPWR cables, even with an adapter, for Wormhole cards. The 12VHPWR connector is physically incompatible and electrically unsafe for EPS12V devices. Only PSU-manufacturer-supplied or approved EPS12V cables or adapters should be used to avoid overheating, connector damage, or other hardware failure.
+
+For safe operation, the EPS12V connector must be fully seated, and tight bends near the connector should be avoided.


### PR DESCRIPTION
Added power supply adapter information to the blackhole card FAQ and created a WH card FAQ with the same information. Added a note with a link in the hardware installation guide to point to the FAQ if they don't have an available power connector as specified. Updated the QSFP question on the BH card FAQ with links to our store page now that we stock them.