### PR TITLE
docs: add Cloud-Native Support section

### DIFF
--- a/cloud-native-support/Makefile
+++ b/cloud-native-support/Makefile
@@ -1,0 +1,56 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# Repo root (parent of this core/ directory) — for venv + shared theme watch
+THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+REPO_ROOT     := $(abspath $(dir $(THIS_MAKEFILE))..)
+VENV_PY       := $(REPO_ROOT)/.venv/bin/python
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+# Same layout as `make html` (sphinx -M html writes HTML under $(BUILDDIR)/html/).
+WEBROOT       = $(BUILDDIR)/html
+
+HOST          ?= 127.0.0.1
+PORT          ?= 3000
+SERVE_PORT    ?= 8766
+# Base URL the top-nav links are built from (conf.py reads the `homepage` env
+# var). CI sets this to the public base URL; locally the core build is served
+# at the server root, so default to "/". Without it the nav renders "None…"
+# links that 404.
+HOMEPAGE      ?= /
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Development (watch): sphinx-autobuild. Run from core/: cd core && make watch
+watch:
+	@test -x "$(VENV_PY)" || (echo "Missing $(VENV_PY) — run: cd \"$(REPO_ROOT)\" && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" >&2; exit 1)
+	@echo ""
+	@echo "Preview: http://$(HOST):$(PORT)/forge/index.html"
+	@echo ""
+	@homepage="$(HOMEPAGE)" "$(VENV_PY)" -m sphinx_autobuild "$(SOURCEDIR)" "$(WEBROOT)" $(SPHINXOPTS) $(O) \
+		--port $(PORT) --host $(HOST) \
+		--watch "$(REPO_ROOT)/shared" \
+		--watch "$(REPO_ROOT)/syseng"
+
+# One-shot HTML build + stdlib HTTP server (no live reload).
+serve:
+	@test -x "$(VENV_PY)" || (echo "Missing $(VENV_PY) — run: cd \"$(REPO_ROOT)\" && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" >&2; exit 1)
+	@homepage="$(HOMEPAGE)" "$(VENV_PY)" -m sphinx -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo ""
+	@echo "Serving: http://$(HOST):$(SERVE_PORT)/forge/index.html"
+	@echo ""
+	@cd "$(WEBROOT)" && "$(VENV_PY)" -m http.server $(SERVE_PORT) --bind $(HOST)
+
+.PHONY: help Makefile watch serve
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# `make mode` option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/cloud-native-support/conf.py
+++ b/cloud-native-support/conf.py
@@ -1,0 +1,40 @@
+# Cloud-Native Support — section landing page for docs.tenstorrent.com.
+# A small hub project that links out to tt-operator and its component docsites,
+# each of which is published independently from its own repo.
+import os
+from pathlib import Path
+
+project = "Cloud-Native Support"
+copyright = "2025, Tenstorrent"
+author = "Tenstorrent"
+html_title = "Cloud-Native Support"
+
+extensions = [
+    "myst_parser",
+    "sphinx_copybutton",
+    "sphinx_togglebutton",
+]
+myst_enable_extensions = ["colon_fence", "deflist"]
+source_suffix = {".md": "markdown", ".rst": "restructuredtext"}
+
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
+templates_path = ["../shared/_templates"]
+html_static_path = ["../shared/_static"]
+html_logo = "../shared/images/tt_logo.svg"
+html_favicon = "../shared/images/favicon.png"
+html_last_updated_fmt = "%b %d, %Y"
+
+_BASE = "https://docs.tenstorrent.com/"
+html_context = {
+    "logo_link_url": os.environ.get("homepage") or _BASE,
+    "search_site_base_url": _BASE,
+}
+
+
+def setup(app):
+    app.add_css_file("tt_theme.css")

--- a/cloud-native-support/conf.py
+++ b/cloud-native-support/conf.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 
 project = "Cloud-Native Support"
-copyright = "2025, Tenstorrent"
+copyright = "2026, Tenstorrent"
 author = "Tenstorrent"
 html_title = "Cloud-Native Support"
 

--- a/cloud-native-support/conf.py
+++ b/cloud-native-support/conf.py
@@ -31,6 +31,9 @@ html_last_updated_fmt = "%b %d, %Y"
 
 _BASE = "https://docs.tenstorrent.com/"
 html_context = {
+    # Sentinel: renders the CNS switcher with no component expanded (the hub
+    # is not one of the components).
+    "cns_component": "cloud-native-support",
     "logo_link_url": os.environ.get("homepage") or _BASE,
     "search_site_base_url": _BASE,
 }

--- a/cloud-native-support/index.md
+++ b/cloud-native-support/index.md
@@ -1,0 +1,48 @@
+# Cloud-Native Support
+
+Run Tenstorrent accelerators on Kubernetes. `tt-operator` is the umbrella Helm
+chart that installs and coordinates the components below. Each component
+maintains and publishes its own documentation; follow a link to get started.
+
+```{toctree}
+:hidden:
+
+TT-Operator <https://docs.tenstorrent.com/tt-operator/>
+Node Feature Discovery <https://docs.tenstorrent.com/tt-operator/components/node-feature-discovery.html>
+Driver Manager <https://docs.tenstorrent.com/tt-k8s-driver-manager/>
+Firmware <https://docs.tenstorrent.com/tt-k8s-driver-manager/firmware.html>
+Telemetry <https://docs.tenstorrent.com/tt-telemetry/>
+Fabric Manager (beta) <https://docs.tenstorrent.com/tt-fabric-manager/>
+Device Allocation (beta) <https://docs.tenstorrent.com/tt-dra-driver/>
+Multi-Node Scheduling (beta) <https://docs.tenstorrent.com/tt-operator/components/multi-node.html>
+```
+
+## Get started
+
+- **[TT-Operator](https://docs.tenstorrent.com/tt-operator/)** — the umbrella
+  Helm chart. Install, configure, and operate Tenstorrent devices on Kubernetes.
+
+## Components
+
+- **[Node Feature Discovery](https://docs.tenstorrent.com/tt-operator/components/node-feature-discovery.html)**
+  — labels nodes that have Tenstorrent devices.
+- **[Driver Manager](https://docs.tenstorrent.com/tt-k8s-driver-manager/)** —
+  installs, upgrades, and scopes the kernel-mode driver (`tt-kmd`) via policy.
+- **[Firmware](https://docs.tenstorrent.com/tt-k8s-driver-manager/firmware.html)**
+  — flashes device firmware via a policy resource.
+- **[Telemetry](https://docs.tenstorrent.com/tt-telemetry/)** — exposes a
+  Prometheus `/metrics` endpoint for Tenstorrent devices.
+
+## Beta
+
+```{attention}
+The components below are installed by default and usable for evaluation. Some
+capabilities are still maturing and may change.
+```
+
+- **[Fabric Manager](https://docs.tenstorrent.com/tt-fabric-manager/)** —
+  resolves fabric topology across devices and hosts.
+- **[Device Allocation](https://docs.tenstorrent.com/tt-dra-driver/)** —
+  publishes devices as schedulable resources (Dynamic Resource Allocation).
+- **[Multi-Node Scheduling](https://docs.tenstorrent.com/tt-operator/components/multi-node.html)**
+  — JobSet and PMIx wiring for multi-node jobs.

--- a/cloud-native-support/index.md
+++ b/cloud-native-support/index.md
@@ -2,20 +2,8 @@
 
 Run Tenstorrent accelerators on Kubernetes. `tt-operator` is the umbrella Helm
 chart that installs and coordinates the components below. Each component
-maintains and publishes its own documentation. Follow a link to get started.
-
-```{toctree}
-:hidden:
-
-TT-Operator <https://docs.tenstorrent.com/tt-operator/>
-Node Feature Discovery <https://docs.tenstorrent.com/tt-operator/components/node-feature-discovery.html>
-Driver Manager <https://docs.tenstorrent.com/tt-k8s-driver-manager/>
-Firmware <https://docs.tenstorrent.com/tt-k8s-driver-manager/firmware.html>
-Telemetry <https://docs.tenstorrent.com/tt-telemetry/>
-Fabric Manager (beta) <https://docs.tenstorrent.com/tt-fabric-manager/>
-Device Allocation (beta) <https://docs.tenstorrent.com/tt-dra-driver/>
-Multi-Node Scheduling (beta) <https://docs.tenstorrent.com/tt-operator/components/multi-node.html>
-```
+maintains and publishes its own documentation. Use the sidebar or a link below
+to get started.
 
 ## Get started
 

--- a/cloud-native-support/index.md
+++ b/cloud-native-support/index.md
@@ -2,7 +2,7 @@
 
 Run Tenstorrent accelerators on Kubernetes. `tt-operator` is the umbrella Helm
 chart that installs and coordinates the components below. Each component
-maintains and publishes its own documentation; follow a link to get started.
+maintains and publishes its own documentation. Follow a link to get started.
 
 ```{toctree}
 :hidden:

--- a/cloud-native-support/index.md
+++ b/cloud-native-support/index.md
@@ -12,25 +12,17 @@ to get started.
 
 ## Components
 
-- **[Node Feature Discovery](https://docs.tenstorrent.com/tt-operator/components/node-feature-discovery.html)**
+- **[Node Feature Discovery](https://docs.tenstorrent.com/tt-operator/latest/components/node-feature-discovery.html)**
   — labels nodes that have Tenstorrent devices.
 - **[Driver Manager](https://docs.tenstorrent.com/tt-k8s-driver-manager/)** —
   installs, upgrades, and scopes the kernel-mode driver (`tt-kmd`) via policy.
-- **[Firmware](https://docs.tenstorrent.com/tt-k8s-driver-manager/firmware.html)**
+- **[Firmware](https://docs.tenstorrent.com/tt-k8s-driver-manager/latest/firmware.html)**
   — flashes device firmware via a policy resource.
 - **[Telemetry](https://docs.tenstorrent.com/tt-telemetry/)** — exposes a
   Prometheus `/metrics` endpoint for Tenstorrent devices.
-
-## Beta
-
-```{attention}
-The components below are installed by default and usable for evaluation. Some
-capabilities are still maturing and may change.
-```
-
 - **[Fabric Manager](https://docs.tenstorrent.com/tt-fabric-manager/)** —
   resolves fabric topology across devices and hosts.
 - **[Device Allocation](https://docs.tenstorrent.com/tt-dra-driver/)** —
   publishes devices as schedulable resources (Dynamic Resource Allocation).
-- **[Multi-Node Scheduling](https://docs.tenstorrent.com/tt-operator/components/multi-node.html)**
+- **[Multi-Node Scheduling](https://docs.tenstorrent.com/tt-operator/latest/components/multi-node.html)**
   — JobSet and PMIx wiring for multi-node jobs.

--- a/cloud-native-support/make.bat
+++ b/cloud-native-support/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/core/_static/assets/home/cloud-native-support.svg
+++ b/core/_static/assets/home/cloud-native-support.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" role="img" aria-label="Cloud-Native Support">
+  <!-- Interim placeholder tile: CNS teal background + the Tenstorrent mark
+       (recolored monochrome to match the other Software card icons). Swap for a
+       real Cloud-Native Support icon when one exists. -->
+  <rect width="600" height="600" fill="#e5f2f1"/>
+  <g transform="translate(152.2 150.3) scale(0.82)" fill="#3A5452">
+    <polygon points="266.3 207.5 180.3 257.1 94.3 207.5 94.3 306.8 180.3 356.4 266.3 306.8 266.3 207.5"/>
+    <polygon points="266.3 108.2 180.3 157.8 94.3 108.2 94.3 207.5 8.3 157.8 8.3 58.5 94.3 8.8 266.3 108.2"/>
+    <polygon points="266.3 207.5 352.3 157.8 352.3 58.5 266.3 8.8 266.3 207.5"/>
+  </g>
+</svg>

--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -602,6 +602,15 @@
               <p class="card-desc">Low-level C++ SDK for writing custom kernels on Tensix cores.</p>
             </div>
           </a>
+          <a href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener" class="card">
+            <div class="card-img">
+              <img src="_static/home/cloud-native-support.svg" alt="Cloud-Native Support" />
+            </div>
+            <div class="card-text">
+              <p class="card-title">Cloud-Native Support</p>
+              <p class="card-desc">Run Tenstorrent accelerators on Kubernetes — install, configure, and operate the device stack.</p>
+            </div>
+          </a>
         </div>
       </div>
 

--- a/core/index.rst
+++ b/core/index.rst
@@ -35,6 +35,7 @@ Tenstorrent
    TT-Lang™ <https://docs.tenstorrent.com/tt-lang/>
    TT-MLIR™ <https://docs.tenstorrent.com/tt-mlir/>
    TT-Metalium™ <https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/>
+   Cloud-Native Support <https://docs.tenstorrent.com/cloud-native-support/>
    tools/index
 
 .. toctree::

--- a/core/software/index.rst
+++ b/core/software/index.rst
@@ -42,6 +42,13 @@ the lower layers are available when you need finer control.
          <span class="tt-doc-card-desc">Low-level C++ SDK for writing custom kernels on Tensix cores.</span>
        </span>
      </a>
+     <a class="tt-doc-card" href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener">
+       <span class="tt-doc-card-img"><img src="../_static/home/cloud-native-support.svg" alt="Cloud-Native Support" /></span>
+       <span class="tt-doc-card-text">
+         <span class="tt-doc-card-title">Cloud-Native Support</span>
+         <span class="tt-doc-card-desc">Run Tenstorrent accelerators on Kubernetes — install, configure, and operate the device stack.</span>
+       </span>
+     </a>
    </div>
 
 Choosing your entry point

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -222,9 +222,9 @@
   {"label": "Node Feature Discovery",       "code": "tt-operator",           "primary": false, "page": "components/node-feature-discovery", "url": "https://docs.tenstorrent.com/tt-operator/latest/components/node-feature-discovery.html"},
   {"label": "Driver Manager",               "code": "tt-k8s-driver-manager", "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-k8s-driver-manager/"},
   {"label": "Telemetry",                    "code": "tt-telemetry",          "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-telemetry/"},
-  {"label": "Fabric Manager (beta)",        "code": "tt-fabric-manager",     "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-fabric-manager/"},
-  {"label": "Device Allocation (beta)",     "code": "tt-dra-driver",         "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-dra-driver/"},
-  {"label": "Multi-Node Scheduling (beta)", "code": "tt-operator",           "primary": false, "page": "components/multi-node",             "url": "https://docs.tenstorrent.com/tt-operator/latest/components/multi-node.html"},
+  {"label": "Fabric Manager",               "code": "tt-fabric-manager",     "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-fabric-manager/"},
+  {"label": "Device Allocation",            "code": "tt-dra-driver",         "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-dra-driver/"},
+  {"label": "Multi-Node Scheduling",        "code": "tt-operator",           "primary": false, "page": "components/multi-node",             "url": "https://docs.tenstorrent.com/tt-operator/latest/components/multi-node.html"},
 ] %}
 {%- set ns = namespace(subpage_active=false) %}
 {%- for c in cns_items %}

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -191,9 +191,13 @@
 </a>
 {%- endif %}
 
+{%- if cns_component is defined and cns_component %}
+<a href="https://docs.tenstorrent.com/cloud-native-support/">Cloud-Native Support</a>
+{%- else %}
 <a href="{{ pathto(_root_doc) }}">
     {{ project }}
 </a>
+{%- endif %}
 
 {%- endblock %}
 
@@ -235,7 +239,6 @@
       | replace('toctree-l3', 'toctree-l4')
       | replace('toctree-l2', 'toctree-l3')
       | replace('toctree-l1', 'toctree-l2') %}
-<p class="caption" role="heading"><span class="caption-text">Cloud-Native Support</span></p>
 <ul>
 {%- for c in cns_items %}
 {%- set primary_current = (c.code == cns_component and c.primary and not ns.subpage_active) %}

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -35,6 +35,7 @@
           <a href="https://docs.tenstorrent.com/tt-lang/" target="_blank" rel="noopener">TT-Lang</a>
           <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
+          <a href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener">Cloud-Native Support</a>
         </div>
       </li>
       <li class="has-dropdown">

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -3,6 +3,24 @@
 {#── PostHog analytics: loaded site-wide (all projects share this layout) ─#}
 {%- block extrahead %}{{ super() }}
   <script src="{{ pathto('_static/posthog.js', 1) }}"></script>
+{%- if cns_component is defined and cns_component %}
+  <style>
+  /* Nested section captions read as sub-headings, out-dented ~8px left of items. */
+  .wy-menu-vertical li.cns-current > p.caption { padding-left: 15px; margin-top: .6em; font-size: .8em; opacity: .8; }
+  /* Same-origin cross-links open in the same tab (see sidebar-carets.js); drop the new-tab icon. */
+  .wy-menu-vertical a.reference.external.tt-same-origin::after { content: none; }
+  /* Caret: tight, centered box (no asymmetric padding) so the rotated "down" state stays vertically centered. */
+  .wy-menu-vertical li:has(> ul) > a::after { padding-left: 0; width: 1em; text-align: center; }
+  /* Highlight only the current page, not every descendant of an expanded section,
+     so the row spacing reads consistently across all levels. */
+  .wy-menu-vertical li.toctree-l2.current li.toctree-l3:not(.current) > a,
+  .wy-menu-vertical li.toctree-l3.current li.toctree-l4:not(.current) > a,
+  .wy-menu-vertical li.toctree-l4.current li.toctree-l5:not(.current) > a { background-color: transparent !important; }
+  /* Flex `gap` only applies between siblings, not before the first child, so a
+     parent's first nested item sits flush against it — add the same 4px gap. */
+  .wy-menu-vertical a + ul { margin-top: 4px; }
+  </style>
+{%- endif %}
 {%- endblock %}
 
 {#── Top navbar injected before the RTD grid ─────────────────────#}
@@ -181,6 +199,61 @@
 
 {#── Suppress RTD built-in version flyout (we have our own switcher) ─#}
 {%- block versions %}{% endblock %}
+
+{#── Left sidebar: shared Cloud-Native Support switcher ───────────
+    The 8-component list is the shared manifest. It renders only when a site
+    opts in via html_context["cns_component"], so non-CNS projects (core, etc.)
+    fall through to the default menu. Links are `reference internal` -> same
+    tab, no external icon. The current site's own page tree nests one level
+    under its entry (the toctree level-shift), expandable via the .tt-open
+    caret (driven by tt-search.js). Page-aware: Node Feature Discovery +
+    Multi-Node live in tt-operator and Firmware in tt-k8s-driver-manager, so on
+    those sub-pages the entry highlights and its host collapses to a plain
+    link. The hub sets the sentinel "cloud-native-support" -> all 8 render,
+    none expanded. ─#}
+{%- block menu %}
+{%- if cns_component is defined and cns_component %}
+{%- set cns_items = [
+  {"label": "TT-Operator",                  "code": "tt-operator",           "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-operator/"},
+  {"label": "Node Feature Discovery",       "code": "tt-operator",           "primary": false, "page": "components/node-feature-discovery", "url": "https://docs.tenstorrent.com/tt-operator/components/node-feature-discovery.html"},
+  {"label": "Driver Manager",               "code": "tt-k8s-driver-manager", "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-k8s-driver-manager/"},
+  {"label": "Firmware",                     "code": "tt-k8s-driver-manager", "primary": false, "page": "firmware",                           "url": "https://docs.tenstorrent.com/tt-k8s-driver-manager/firmware.html"},
+  {"label": "Telemetry",                    "code": "tt-telemetry",          "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-telemetry/"},
+  {"label": "Fabric Manager (beta)",        "code": "tt-fabric-manager",     "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-fabric-manager/"},
+  {"label": "Device Allocation (beta)",     "code": "tt-dra-driver",         "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-dra-driver/"},
+  {"label": "Multi-Node Scheduling (beta)", "code": "tt-operator",           "primary": false, "page": "components/multi-node",             "url": "https://docs.tenstorrent.com/tt-operator/components/multi-node.html"},
+] %}
+{%- set ns = namespace(subpage_active=false) %}
+{%- for c in cns_items %}
+{%- if c.code == cns_component and not c.primary and c.page == pagename %}{% set ns.subpage_active = true %}{% endif %}
+{%- endfor %}
+{#- Telemetry's Metrics page has 81 child pages; cap its depth so the sidebar
+    shows Metrics + Configuration without exploding the metric list (the full
+    list stays reachable from the Metrics page body). -#}
+{%- set _navdepth = 1 if cns_component == 'tt-telemetry' else 4 %}
+{%- set component_nav = toctree(maxdepth=_navdepth, collapse=True, includehidden=True, titles_only=True)
+      | replace('toctree-l4', 'toctree-l5')
+      | replace('toctree-l3', 'toctree-l4')
+      | replace('toctree-l2', 'toctree-l3')
+      | replace('toctree-l1', 'toctree-l2') %}
+<p class="caption" role="heading"><span class="caption-text">Cloud-Native Support</span></p>
+<ul>
+{%- for c in cns_items %}
+{%- set primary_current = (c.code == cns_component and c.primary and not ns.subpage_active) %}
+{%- set subpage_current = (c.code == cns_component and not c.primary and c.page == pagename) %}
+{%- if primary_current %}
+  <li class="toctree-l1 current cns-current"><a class="reference internal current" href="{{ c.url }}">{{ c.label }}</a>
+  {{ component_nav }}
+  </li>
+{%- else %}
+  <li class="toctree-l1{% if subpage_current %} current{% endif %}"><a class="reference internal{% if subpage_current %} current{% endif %}" href="{{ c.url }}">{{ c.label }}</a></li>
+{%- endif %}
+{%- endfor %}
+</ul>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}
 
 {#── Content: default + feedback widget ──────────────────────────#}
 {%- block content %}

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -215,13 +215,12 @@
 {%- if cns_component is defined and cns_component %}
 {%- set cns_items = [
   {"label": "TT-Operator",                  "code": "tt-operator",           "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-operator/"},
-  {"label": "Node Feature Discovery",       "code": "tt-operator",           "primary": false, "page": "components/node-feature-discovery", "url": "https://docs.tenstorrent.com/tt-operator/components/node-feature-discovery.html"},
+  {"label": "Node Feature Discovery",       "code": "tt-operator",           "primary": false, "page": "components/node-feature-discovery", "url": "https://docs.tenstorrent.com/tt-operator/latest/components/node-feature-discovery.html"},
   {"label": "Driver Manager",               "code": "tt-k8s-driver-manager", "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-k8s-driver-manager/"},
-  {"label": "Firmware",                     "code": "tt-k8s-driver-manager", "primary": false, "page": "firmware",                           "url": "https://docs.tenstorrent.com/tt-k8s-driver-manager/firmware.html"},
   {"label": "Telemetry",                    "code": "tt-telemetry",          "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-telemetry/"},
   {"label": "Fabric Manager (beta)",        "code": "tt-fabric-manager",     "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-fabric-manager/"},
   {"label": "Device Allocation (beta)",     "code": "tt-dra-driver",         "primary": true,  "page": "index",                              "url": "https://docs.tenstorrent.com/tt-dra-driver/"},
-  {"label": "Multi-Node Scheduling (beta)", "code": "tt-operator",           "primary": false, "page": "components/multi-node",             "url": "https://docs.tenstorrent.com/tt-operator/components/multi-node.html"},
+  {"label": "Multi-Node Scheduling (beta)", "code": "tt-operator",           "primary": false, "page": "components/multi-node",             "url": "https://docs.tenstorrent.com/tt-operator/latest/components/multi-node.html"},
 ] %}
 {%- set ns = namespace(subpage_active=false) %}
 {%- for c in cns_items %}

--- a/versions.yml
+++ b/versions.yml
@@ -4,3 +4,4 @@ core:
 ttnn:
 tt-metalium:
 syseng:
+cloud-native-support:


### PR DESCRIPTION
## Summary

Adds the **Cloud-Native Support** section to docs.tenstorrent.com — running
Tenstorrent accelerators on Kubernetes (tt-operator + its components).

## Changes

- **`cloud-native-support/`** — a new hub project linking out to tt-operator and
  each component's own docsite. Registered in `versions.yml` so `build_docs.py`
  publishes it at `docs.tenstorrent.com/cloud-native-support/`.
- **`shared/_templates/layout.html`** — two additions:
  - a "Cloud-Native Support" entry in the **Software** top-nav dropdown; and
  - a guarded **left-sidebar switcher** (`{% block menu %}`): the 8-component
    list, with the current component expanded into its own pages. It renders
    only when `html_context["cns_component"]` is set (the hub + each component
    repo set it), so every other docs.tenstorrent.com project falls through to
    the default menu, unchanged.
- **Landing-page surfacing (`core/`)** — a "Cloud-Native Support" entry in the
  three places the other software products appear, all linking to the
  `/cloud-native-support/` hub: the home-page Software card grid (`home.html`),
  the Software overview body cards (`software/index.rst`), and the left-sidebar
  Software toctree under TT-Metalium (`index.rst`). Ships an interim placeholder
  icon (`cloud-native-support.svg` — CNS teal tile + the monochrome Tenstorrent
  mark) matching the other card icons until a real asset exists.

> ⚠️ **For docs-platform reviewers:** this touches the shared `layout.html`. The
> switcher is fully guarded by `cns_component`, so it's inert for all non-CNS
> projects — please confirm the guard approach is acceptable.

## Merge ordering

The hub + landing links point at `docs.tenstorrent.com/<component>/` pages
published from each component repo. Most are already live; merge once the
remaining component docsite (tt-telemetry) is deployed so every link resolves.
Companion PRs:
- Theme + tag-gated Pages (merged): tenstorrent/tt-operator#140, tenstorrent/tt-k8s-driver-manager#43, tenstorrent/tt-telemetry#279, tenstorrent/tt-fabric-manager#320, tenstorrent/tt-dra-driver#15
- Sidebar switcher (open, to land near the component releases): tenstorrent/tt-operator#143, tenstorrent/tt-k8s-driver-manager#54, tenstorrent/tt-telemetry#287, tenstorrent/tt-fabric-manager#325, tenstorrent/tt-dra-driver#17

## Verification

Built `cloud-native-support` + the five component sites against this shared theme
into one local tree: the Software → Cloud-Native Support top-nav entry works; the
landing page and Software overview both show the Cloud-Native Support card; the
left sidebar shows the persistent 8-component switcher with the current component
expanded (same-tab links, no external-tab icon); the core docs sidebar is
unchanged (the `cns_component` guard isolates non-CNS projects).
