### PR TITLE
docs: harden sphinx conf.py for core, syseng, tt-metalium, ttnn sub-sites

### DIFF
--- a/core/conf.py
+++ b/core/conf.py
@@ -23,7 +23,23 @@ extensions = ['myst_parser',
               'sphinx_copybutton',
               'sphinx_togglebutton',
               'sphinx_sitemap',
+              'sphinx_reredirects',
               ]
+
+# Redirects for pages that were consolidated — preserves incoming links.
+redirects = {
+    "systems/quietbox/quietbox-bh/setup": "index.html#receiving-unboxing-and-setup",
+    "systems/quietbox/quietbox-bh/specifications": "index.html#specifications-and-requirements",
+    "systems/quietbox/quietbox-wh/setup": "index.html#receiving-unboxing-and-setup",
+    "systems/quietbox/quietbox-wh/specifications": "index.html#specifications-and-requirements",
+    "systems/t3000/specifications": "index.html#specifications-requirements-and-setup",
+    "systems/t3000/support": "index.html#support",
+    "aibs/blackhole/installation": "index.html#hardware-installation",
+    "aibs/blackhole/specifications": "index.html#specifications-and-requirements",
+    "aibs/blackhole/support": "index.html#troubleshooting-common-hardware-issues",
+    "aibs/wormhole/installation": "index.html#hardware-installation",
+    "aibs/wormhole/specifications": "index.html#specifications-requirements",
+}
 
 html_baseurl = "https://docs.tenstorrent.com/"
 sitemap_filename = "sitemap_core.xml"
@@ -53,6 +69,11 @@ myst_heading_anchors = 3  # or 2, depending on how deep you want anchor links
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
 html_logo = "../shared/images/tt_logo.svg"
 html_favicon = "../shared/images/favicon.png"
 html_static_path = ['../shared/_static', '_static/assets', '_static/js']
@@ -60,12 +81,13 @@ html_static_path = ['../shared/_static', '_static/assets', '_static/js']
 # `_extra/` holds llms.txt and AGENTS.md so they serve at docs.tenstorrent.com/llms.txt
 # and /AGENTS.md. See core/_extra/AGENTS.md "Maintenance" for how to regenerate them.
 html_extra_path = ['_extra']
-html_js_files = ['custom.js', 'posthog.js']
+html_js_files = ['custom.js']  # posthog.js loaded site-wide via shared/_templates/layout.html extrahead
 html_last_updated_fmt = "%b %d, %Y"
 
 html_context = {
-    "versions": None, # Do not render versions
-    "logo_link_url": os.environ.get("homepage")
+    "versions": None,
+    "logo_link_url": os.environ.get("homepage") or "https://docs.tenstorrent.com/",
+    "search_site_base_url": "https://docs.tenstorrent.com/",
 }
 
 def setup(app):

--- a/syseng/conf.py
+++ b/syseng/conf.py
@@ -21,12 +21,11 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     'display_version': True,
     'style_external_links': True,
-    # Toc options
-    'collapse_navigation': True,
+    'collapse_navigation': False,
     'sticky_navigation': True,
-    'navigation_depth': 4,
+    'navigation_depth': 2,
     'includehidden': True,
-    'titles_only': False
+    'titles_only': True,
 }
 
 html_logo = "../shared/images/tt_logo.svg"
@@ -40,7 +39,8 @@ html_context = {
     "versions": versions,
     "project_code": "syseng",
     "current_version": os.environ.get("current_version"),
-    "logo_link_url": os.environ.get("homepage")
+    "logo_link_url": os.environ.get("homepage") or "https://docs.tenstorrent.com/",
+    "search_site_base_url": "https://docs.tenstorrent.com/",
 }
 
 version = os.environ.get("current_version")

--- a/tt-metalium/conf.py
+++ b/tt-metalium/conf.py
@@ -85,6 +85,11 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
 html_logo = "../shared/images/tt_logo.svg"
 html_favicon = "../shared/images/favicon.png"
 html_static_path = ['../shared/_static']
@@ -100,7 +105,8 @@ html_context = {
     "versions": list(versions["versions"].keys()),
     "project_code": metal_sphinx_config.shortname,
     "current_version": os.environ.get("current_version"),
-    "logo_link_url": os.environ.get("homepage")
+    "logo_link_url": os.environ.get("homepage") or "https://docs.tenstorrent.com/",
+    "search_site_base_url": "https://docs.tenstorrent.com/",
 }
 
 version = os.environ.get("current_version")

--- a/ttnn/conf.py
+++ b/ttnn/conf.py
@@ -86,6 +86,11 @@ exclude_patterns = []
 #
 
 html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
 html_logo = "../shared/images/tt_logo.svg"
 html_favicon = "../shared/images/favicon.png"
 html_static_path = ['../shared/_static']
@@ -106,7 +111,8 @@ html_context = {
     "versions": list(versions["versions"].keys()),
     "project_code": metal_sphinx_config.shortname,
     "current_version": os.environ.get("current_version"),
-    "logo_link_url": os.environ.get("homepage")
+    "logo_link_url": os.environ.get("homepage") or "https://docs.tenstorrent.com/",
+    "search_site_base_url": "https://docs.tenstorrent.com/",
 }
 
 def setup(app):


### PR DESCRIPTION
## Summary

- `core/conf.py`, `syseng/conf.py`, `tt-metalium/conf.py`, `ttnn/conf.py`:
  - Added consistent `html_theme_options` (collapse_navigation, titles_only, navigation_depth)
  - Added `search_site_base_url` and `logo_link_url` to `html_context`
  - Added `sphinx_reredirects` extension + redirect rules for consolidated navigation URLs
  - Added `sphinx_sitemap` settings

No versioning changes (html_baseurl, versions.yml untouched).

## Merge order

Can be merged after `docs/shared-layout-nav-search` is live.

## Test plan

- [ ] All 4 sub-sites build without warnings
- [ ] Redirect rules return HTTP 301 for old URLs
- [ ] Sitemap generated at `/sitemap.xml`