### PR TITLE
ci: add OpenSearch indexing step to docs deploy workflow

### DIFF
--- a/.github/workflows/pages_deploy.yml
+++ b/.github/workflows/pages_deploy.yml
@@ -10,10 +10,22 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-24.04
+    environment: github-pages
+    env:
+      SEARCH_API_BASE: https://csl860x2oj.execute-api.us-east-2.amazonaws.com/prod
+      DOC_CATALOG_SOURCE_ID: docs-tenstorrent
+      DOC_SITE_BASE_URL: https://docs.tenstorrent.com
+      DOCS_ID_NAMESPACE: tenstorrent
+      DOCS_INDEX_VERSION: latest
+      DOCS_OUTPUT_DIR: output
+      DOCS_SEARCH_INGEST_API_KEY: ${{ secrets.DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -51,10 +63,24 @@ jobs:
         run: |
           source .docs-env/bin/activate
           python build_docs.py
-      - name: Make root index.html
+      - name: Make root index.html and nojekyll
         run: |
           touch output/index.html
+          touch output/.nojekyll
           echo -n "docs.tenstorrent.com" > output/CNAME
+
+      - name: Warn if search ingest key is missing
+        if: ${{ env.DOCS_SEARCH_INGEST_API_KEY == '' }}
+        run: |
+          echo "::warning::Skipping OpenSearch indexing: DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT secret not set."
+
+      - name: Index docs into OpenSearch
+        if: ${{ env.DOCS_SEARCH_INGEST_API_KEY != '' }}
+        continue-on-error: true
+        run: |
+          source .docs-env/bin/activate
+          python scripts/index_remote_search.py
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/scripts/index_remote_search.py
+++ b/scripts/index_remote_search.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Crawl the built docs in output/ and push them to the OpenSearch-backed
+docs search service so the in-page search modal has something to query.
+
+Configured entirely through environment variables (see main()); intended to run
+as a step in the Pages deploy workflow after `python build_docs.py`."""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Iterable
+
+
+# Keep batches small: the indexer Lambda fans each batch out to an OpenSearch
+# _bulk call, and API Gateway caps the request at ~29s. 200 docs in one POST
+# times out (HTTP 504) on the larger catalogs; 50 stays comfortably under it.
+MAX_BATCH_SIZE = 50
+TIMEOUT_SECONDS = 30
+
+
+def _strip_html_to_text(content: str) -> str:
+    # Remove script/style blocks first so they do not pollute search text.
+    content = re.sub(r"<script\b[^>]*>.*?</script>", " ", content, flags=re.IGNORECASE | re.DOTALL)
+    content = re.sub(r"<style\b[^>]*>.*?</style>", " ", content, flags=re.IGNORECASE | re.DOTALL)
+    # Strip tags.
+    content = re.sub(r"<[^>]+>", " ", content)
+    # Decode entities and normalize whitespace.
+    content = html.unescape(content)
+    content = re.sub(r"\s+", " ", content).strip()
+    return content
+
+
+def _extract_title(content: str, fallback: str) -> str:
+    match = re.search(r"<title[^>]*>(.*?)</title>", content, flags=re.IGNORECASE | re.DOTALL)
+    if not match:
+        return fallback
+    return _strip_html_to_text(match.group(1)) or fallback
+
+
+def _iter_html_files(output_root: Path) -> Iterable[Path]:
+    for path in output_root.rglob("*.html"):
+        rel = path.relative_to(output_root).as_posix()
+        if rel.startswith("_static/") or rel.startswith("_sources/"):
+            continue
+        if "/_static/" in rel or "/_sources/" in rel:
+            continue
+        # Skip Sphinx's own search/genindex shell pages — they carry no content.
+        name = path.name
+        if name in {"search.html", "genindex.html"}:
+            continue
+        yield path
+
+
+def _build_documents(output_root: Path, site_base_url: str, catalog: str, version: str, id_namespace: str) -> list[dict]:
+    site_base_url = site_base_url.rstrip("/")
+    docs: list[dict] = []
+
+    for html_file in _iter_html_files(output_root):
+        rel = html_file.relative_to(output_root).as_posix()
+        raw = html_file.read_text(encoding="utf-8", errors="ignore")
+        title = _extract_title(raw, rel)
+        body = _strip_html_to_text(raw)
+        doc_id = f"{catalog}:{id_namespace}:{version}:{rel}"
+        url = f"{site_base_url}/{rel}"
+        docs.append({"id": doc_id, "title": title, "body": body, "url": url})
+
+    return docs
+
+
+def _chunks(items: list[dict], size: int) -> Iterable[list[dict]]:
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def _post_json(url: str, payload: dict, api_key: str) -> tuple[int, str]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url=url,
+        method="POST",
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "x-api-key": api_key,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as response:
+            return response.getcode(), response.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as err:
+        return err.code, err.read().decode("utf-8", errors="replace")
+
+
+def main() -> int:
+    api_base = os.environ.get("SEARCH_API_BASE", "").rstrip("/")
+    source_id = os.environ.get("DOC_CATALOG_SOURCE_ID", "").strip()
+    api_key = os.environ.get("DOCS_SEARCH_INGEST_API_KEY", "").strip()
+    output_dir = os.environ.get("DOCS_OUTPUT_DIR", "output").strip()
+    site_base = os.environ.get("DOC_SITE_BASE_URL", "").rstrip("/")
+    version = os.environ.get("DOCS_INDEX_VERSION", "latest").strip()
+    id_namespace = os.environ.get("DOCS_ID_NAMESPACE", "tenstorrent").strip()
+
+    if not api_base:
+        print("Missing SEARCH_API_BASE", file=sys.stderr)
+        return 2
+    if not source_id:
+        print("Missing DOC_CATALOG_SOURCE_ID", file=sys.stderr)
+        return 2
+    if not api_key:
+        print("Missing DOCS_SEARCH_INGEST_API_KEY", file=sys.stderr)
+        return 2
+    if not site_base:
+        print("Missing DOC_SITE_BASE_URL", file=sys.stderr)
+        return 2
+    if not id_namespace:
+        print("Missing DOCS_ID_NAMESPACE", file=sys.stderr)
+        return 2
+
+    output_root = Path(output_dir)
+    if not output_root.exists():
+        print(f"Output directory not found: {output_root}", file=sys.stderr)
+        return 2
+
+    docs = _build_documents(output_root, site_base, source_id, version, id_namespace)
+    if not docs:
+        print("No HTML docs found to index.", file=sys.stderr)
+        return 1
+
+    endpoint = f"{api_base}/v1/index/{source_id}"
+    print(f"Indexing {len(docs)} documents to {endpoint}")
+
+    indexed = 0
+    for batch in _chunks(docs, MAX_BATCH_SIZE):
+        payload = {"version": version, "documents": batch}
+        status, body = _post_json(endpoint, payload, api_key)
+        if status < 200 or status >= 300:
+            print(f"Indexing failed: HTTP {status}", file=sys.stderr)
+            print(body, file=sys.stderr)
+            if status == 403:
+                print(
+                    (
+                        "Hint: DOCS_SEARCH_INGEST_API_KEY must be the API key VALUE, "
+                        "not the API key ID (for example, not '427rdpxpb6')."
+                    ),
+                    file=sys.stderr,
+                )
+            return 1
+        indexed += len(batch)
+        print(f"Indexed {indexed}/{len(docs)}")
+
+    print("Indexing complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- `pages_deploy.yml`: adds OpenSearch env vars, `fetch-depth: 0`, `fetch-tags: true`, warn step (if secret absent), and index step with `continue-on-error: true`
- `scripts/index_remote_search.py`: generic HTML crawler — reads all config from env vars, POSTs batched pages to the OpenSearch ingest API

Indexing failures never block page deploys (`continue-on-error: true`). If the secret `DOCS_SEARCH_INGEST_API_KEY_DOCS_TENSTORRENT` is not set, a warning is emitted and the step is skipped.

## Merge order

Independent — can be merged at any time.

## Test plan

- [ ] Docs deploy still succeeds when secret is absent (warn step fires, index step skipped)
- [ ] Search results appear on `docs.tenstorrent.com` after a deploy with the secret set