### PR TITLE
fix: TT-NN Visualizer links 404 (drop /latest/, match top nav)

### DIFF
--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -769,7 +769,7 @@
               <p class="card-desc">Real-time terminal monitor: power, temperature, current, and core activity.</p>
             </div>
           </a>
-          <a href="https://docs.tenstorrent.com/ttnn-visualizer/latest/" target="_blank" rel="noopener" class="card">
+          <a href="https://docs.tenstorrent.com/ttnn-visualizer/" target="_blank" rel="noopener" class="card">
             <div class="card-text">
               <p class="card-title">TT-NN Visualizer</p>
               <p class="card-desc">Inspect model execution: graphs, memory plots, tensor and buffer views.</p>

--- a/core/tools/index.rst
+++ b/core/tools/index.rst
@@ -53,7 +53,7 @@ Analysis & Visualization
    :class: tt-index-cards
    :widths: 50 50
 
-   * - `TT-NN Visualizer <https://docs.tenstorrent.com/ttnn-visualizer/latest/>`_
+   * - `TT-NN Visualizer <https://docs.tenstorrent.com/ttnn-visualizer/>`_
 
        TT-NN Visualizer is an interactive tool for analyzing model execution on Tenstorrent hardware: graphs, memory plots, tensor and buffer views, operation flow diagrams, and multi-instance support via file or SSH report loading.
      - `Model-Explorer <https://github.com/tenstorrent/model-explorer>`_


### PR DESCRIPTION
## Summary
The **TT-NN Visualizer** link on the home-page tile (and the Tools page) pointed at `https://docs.tenstorrent.com/ttnn-visualizer/latest/`, which **404s**. Production serves the page at `https://docs.tenstorrent.com/ttnn-visualizer/` — the same form already used by the top-nav dropdown. This aligns both links to the working URL.

## Changes
- `core/_templates/home.html` — home-page tile → `…/ttnn-visualizer/`
- `core/tools/index.rst` — Tools page list entry (same 404) → `…/ttnn-visualizer/`

## Verification
- Production: `…/ttnn-visualizer/` → **200**, `…/ttnn-visualizer/latest/` → **404**.
- `core` builds clean (no new warnings); built `index.html` and `tools/index.html` now emit the `…/ttnn-visualizer/` URL.

Follow-up to #179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)