### PR TITLE
fix(mobile): responsive navbar + hero search on narrow viewports

### DIFF
--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -99,6 +99,10 @@
       text-overflow: ellipsis;
     }
 
+    /* On narrow viewports the full prompt overflows the box, so swap it for a
+       short "Search" label (toggled in the max-width: 768px block below). */
+    .hero-search-text-short { display: none; }
+
     .hero-search-kbd {
       font-family: inherit;
       font-size: 12px;
@@ -434,8 +438,11 @@
     @media (max-width: 768px) {
       .navbar-links { display: none; }
       .navbar-right { gap: 12px; }
-      .hero-inner { padding: 60px 24px; }
+      /* Top padding must clear the 72px fixed navbar (was 60px → title overlapped). */
+      .hero-inner { padding: 96px 24px 60px; }
       .hero-title { font-size: 40px; }
+      .hero-search-text-full { display: none; }
+      .hero-search-text-short { display: inline; }
       .hero-right { flex-direction: column; gap: 16px; }
       .page-wrap { padding: 40px 24px; }
       .sections-list { gap: 32px; }
@@ -460,7 +467,10 @@
             <circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.4"/>
             <path d="M11 11l3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
           </svg>
-          <span class="hero-search-placeholder">Ask anything about Tenstorrent hardware and software</span>
+          <span class="hero-search-placeholder">
+            <span class="hero-search-text-full">Ask anything about Tenstorrent hardware and software</span>
+            <span class="hero-search-text-short">Search</span>
+          </span>
           <kbd class="hero-search-kbd">⌘K</kbd>
         </div>
       </div>

--- a/shared/_static/tt_theme.css
+++ b/shared/_static/tt_theme.css
@@ -1074,11 +1074,20 @@ body.tt-search-locked { overflow: hidden; }
   padding: 4px 8px;
 }
 
-@media screen and (max-width: 768px) {
-  /* Navbar: collapse desktop links/search, show hamburger */
-  .tt-nav-links { display: none; }
+/* Between the mobile breakpoint and ~1100px the fixed-width search box and the
+   nav links run out of room and overlap (the right group shrinks but the 220px
+   search box doesn't). Drop the navbar search here — ⌘K still opens it, and the
+   homepage keeps its own hero search. */
+@media screen and (max-width: 1100px) {
   .tt-nav-search-form { display: none; }
-  .tt-nav-actions { display: none; }
+}
+
+/* Below ~900px the desktop top-nav links crowd the Explore CTA, so collapse them
+   into the hamburger here — earlier than the ≤768px content/sidebar breakpoint.
+   Explore stays visible; the secondary Github link drops to make room. */
+@media screen and (max-width: 900px) {
+  .tt-nav-links { display: none; }
+  .tt-nav-btn-github { display: none; }
   .tt-nav-hamburger { display: block; }
   .tt-top-nav { padding: 0 16px; }
   .tt-top-nav-right { gap: 12px; }


### PR DESCRIPTION
## Summary

Fixes several mobile/narrow-viewport UI issues found on the docs site, primarily around the homepage hero and the shared top navbar.

### 1. Hero search placeholder overflow
The homepage hero search box used the long placeholder "Ask anything about Tenstorrent hardware and software", which overflowed/clipped on narrow screens. It now swaps to just **"Search"** at ≤768px (full prompt retained on desktop).

### 2. Navbar overlap as the window narrows
The shared top navbar packs logo + nav links + search + Explore + Github into one row, and items overlapped as the window shrank. Now it degrades in clean stages:

| Width | Navbar contents |
|------|------|
| ≤900px | logo + **Explore** + hamburger |
| 901–1100px | links + Explore + Github |
| ≥1100px | everything incl. search box |

- Search box hidden ≤1100px (⌘K still opens it; homepage keeps its hero search).
- Desktop nav links collapse into the hamburger ≤900px; the secondary Github link drops there too.
- The **Explore** CTA stays visible down to mobile.

### 3. Navbar overlapping the hero title
At ≤768px the hero's top padding (60px) was less than the fixed 72px navbar, so the navbar sat on top of the "Tenstorrent" heading. Bumped the top padding to 96px to clear it.

## Testing
Verified with headless Chrome against a local build across 600 / 800 / 901 / 1100 / 1200px (homepage and a docs page): no overlaps at any width, Explore present down to mobile, and the hero title clears the navbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)