### PR TITLE
fix(home): responsive card grid + hero card overflow on narrow desktop

### DIFF
--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -123,8 +123,12 @@
     .hero-right {
       display: flex;
       gap: 40px;
+      /* width acts as the preferred size; allow shrinking so the cards don't
+         overflow the hero's side padding in the ~1281–1383px range, where the
+         fixed 663px width + the 520px hero-left no longer both fit. */
       width: 663px;
-      flex-shrink: 0;
+      flex-shrink: 1;
+      min-width: 0;
       align-self: center;
     }
 
@@ -248,8 +252,12 @@
     }
 
     .cards-grid {
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      /* Auto-fill responsive columns: cards stretch to fill their row and only
+         drop a column once they'd shrink below ~320px. This keeps 3-up across a
+         wide viewport range instead of snapping to 2-up the moment a rigid
+         360px card no longer fits. min(100%, …) prevents overflow on phones. */
+      grid-template-columns: repeat(auto-fill, minmax(min(100%, 320px), 1fr));
       gap: 32px;
     }
 
@@ -257,13 +265,11 @@
     .card {
       display: flex;
       gap: 16px;
-      width: 360px;
       padding: 16px;
       border-radius: 8px;
       border: 1px solid #c7d9d8;
       background: #fff;
       text-decoration: none;
-      flex-shrink: 0;
       transition: box-shadow 150ms ease;
     }
 
@@ -432,7 +438,6 @@
       .hero-right { width: 100%; }
       .hero-search { width: 100%; }
       .page-wrap { padding: 60px 40px; }
-      .card { width: calc(50% - 16px); }
     }
 
     @media (max-width: 768px) {
@@ -446,7 +451,6 @@
       .hero-right { flex-direction: column; gap: 16px; }
       .page-wrap { padding: 40px 24px; }
       .sections-list { gap: 32px; }
-      .card { width: 100%; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary

Two related homepage responsiveness fixes in `core/_templates/home.html`, both visible when narrowing the browser from full screen on desktop.

### 1. Card grid drops to 2 columns too quickly
The card sections used a fixed-width flexbox (`360px` cards, `flex-shrink: 0`), so a column dropped the instant a whole extra `360 + 32px` card no longer fit — collapsing 3-up to 2-up at ~1384px viewport.

**Fix:** `.cards-grid` → responsive CSS grid `repeat(auto-fill, minmax(min(100%, 320px), 1fr))`. Cards now stretch to fill and 3-up survives down to ~1144px, reflowing smoothly. Removed the now-redundant `.card { width: … }` overrides in the 1024px/768px media queries.

| Width | Before | After |
|---|---|---|
| 1300px | 2 columns | **3 columns** |
| 1100px | 2 | 2 (cards stretch to fill) |
| 600px | 1 | 1 (full-width, no overflow) |

### 2. Hero "TT-VSCode-Toolkit" card touches the right edge
`.hero-right` was `width: 663px` with `flex-shrink: 0`. Between the 1280px flex breakpoint and the ~1383px width where the fixed `663px` + the `520px` hero-left both fit, neither column could shrink, so the right card overflowed the hero's 80px side padding.

**Fix:** allow `.hero-right` to shrink (`flex-shrink: 1`, `min-width: 0`). It still sits at `663px` whenever there's room.

## Testing
Verified locally via `cd core && make watch` with headless screenshots at 600/900/1100/1281/1300/1320/1383/1450/1512px. Card columns reflow correctly and the hero card stays inside its padding across the full range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)