### PR TITLE
docs(qb2): link new TT-QuietBox 2 handbook from QB2 pages

### DIFF
--- a/core/_extra/AGENTS.md
+++ b/core/_extra/AGENTS.md
@@ -43,6 +43,7 @@ project's own docs, trust the project's docs and treat this as orientation.
 | `/tt-CableGen/` | `tt-CableGen` | Scale-out cabling generator |
 | `/tt-system-firmware/` | `tt-system-firmware` | System firmware docs |
 | `/tt-vscode-toolkit/` | `tt-vscode-toolkit` | VS Code extension + lessons |
+| `/tt-quietbox2-guide/` | `tt-quietbox2-guide` | Complete QuietBox 2 handbook (setup → daily use) |
 | `/riescue/`, `/riscv-coretp/` | `riescue`, `riscv-coretp` | RISC-V test framework / core test plan |
 | `/tt-animatediff/`, `/tt-local-generator/` | (same names) | Generative-AI demos |
 | `/tt-awesome/` | `tt-awesome` | Curated ecosystem list |

--- a/core/_extra/llms.txt
+++ b/core/_extra/llms.txt
@@ -103,6 +103,7 @@ Self-contained, hands-on lessons from the [TT Developer Toolkit](https://docs.te
 - [Systems](https://docs.tenstorrent.com/systems/index.html): Pre-built desktop and server systems — setup, specs, support
   - [TT-LoudBox (Blackhole)](https://docs.tenstorrent.com/systems/loudbox-bh/index.html): LoudBox workstation setup, OS setup, and specifications
   - [TT-QuietBox 2 (Blackhole)](https://docs.tenstorrent.com/systems/quietbox/quietbox-bh-2/index.html): QuietBox 2 — 4× P300c, welcome guide, setup, and specs
+    - [TT-QuietBox 2 Guide (handbook)](https://docs.tenstorrent.com/tt-quietbox2-guide/): The complete QuietBox 2 handbook — first boot to confident daily use: setup & first run, system access & management, workloads & development, troubleshooting & recovery, and reference
   - [T3000](https://docs.tenstorrent.com/systems/t3000/index.html): T3000 server system specifications and support
   - [T1000](https://docs.tenstorrent.com/systems/t1000/index.html): T1000 system specifications and support
   - [T7000](https://docs.tenstorrent.com/systems/t7000/index.html): T7000 system specifications and support

--- a/core/systems/quietbox/quietbox-bh-2/index.rst
+++ b/core/systems/quietbox/quietbox-bh-2/index.rst
@@ -10,6 +10,11 @@ TT-QuietBox 2 (Blackhole)
 
    <div class="tt-float-clear" aria-hidden="true"></div>
 
+.. seealso::
+
+   For the complete handbook — from first boot to confident daily use — see the
+   `TT-QuietBox 2 Guide <https://docs.tenstorrent.com/tt-quietbox2-guide/>`_.
+
 Getting Started
 ---------------
 

--- a/core/systems/quietbox/quietbox-bh-2/setup.md
+++ b/core/systems/quietbox/quietbox-bh-2/setup.md
@@ -60,6 +60,10 @@ myst:
 
 This guide shows users how to safely unbox, setup hardware, and install software on a TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) workstation.
 
+```{tip}
+For the complete handbook — system access & management, workloads & development, troubleshooting & recovery, and reference material beyond first setup — see the [**TT-QuietBox 2 Guide**](https://docs.tenstorrent.com/tt-quietbox2-guide/).
+```
+
 ## Before You Begin
 
 Choose a suitable location for your System:

--- a/core/systems/quietbox/quietbox-bh-2/welcome.md
+++ b/core/systems/quietbox/quietbox-bh-2/welcome.md
@@ -394,6 +394,10 @@ canvas.qb2-chip-canvas {
        href="setup.html">
       &#128203; Setup guide
     </a>
+    <a class="qb2-cta-btn qb2-cta-btn-outline"
+       href="https://docs.tenstorrent.com/tt-quietbox2-guide/">
+      &#128214; Full QuietBox 2 Guide
+    </a>
   </div>
 
   <!-- ===== CHIP WIDGET ===== -->
@@ -663,6 +667,11 @@ canvas.qb2-chip-canvas {
     <strong>Hardware setup not finished?</strong> Start with the
     <a href="setup.html">setup guide</a> &mdash; unboxing, first login, verifying chips with tt-smi, and launching your first model.
     Need help? <a href="https://tenstorrent.com/support">Raise a support request.</a>
+  </div>
+  <div class="qb2-note-bar" style="margin-top:8px">
+    <strong>Want the complete handbook?</strong> The
+    <a href="https://docs.tenstorrent.com/tt-quietbox2-guide/">TT-QuietBox 2 Guide</a>
+    covers everything from first boot to daily operation &mdash; setup, system access &amp; management, workloads &amp; development, and troubleshooting &amp; recovery.
   </div>
   <div class="qb2-note-bar" style="margin-top:8px;opacity:.8">
     <strong>Want to try before you install?</strong>


### PR DESCRIPTION
## What

Links the existing TT-QuietBox 2 materials to the new comprehensive handbook published at **https://docs.tenstorrent.com/tt-quietbox2-guide/** (source: \`tenstorrent/tt-quietbox2-guide\`).

## Changes

| File | Change |
|------|--------|
| \`core/systems/quietbox/quietbox-bh-2/welcome.md\` | Added a **Full QuietBox 2 Guide** CTA button + a note-bar pointer |
| \`core/systems/quietbox/quietbox-bh-2/setup.md\` | Added a \`{tip}\` callout linking to the handbook for everything beyond first setup |
| \`core/systems/quietbox/quietbox-bh-2/index.rst\` | Added a \`.. seealso::\` block |
| \`core/_extra/llms.txt\` | Listed the handbook under the TT-QuietBox 2 systems entry |
| \`core/_extra/AGENTS.md\` | Added \`/tt-quietbox2-guide/\` to the doc-site routing map |

## Notes

- URL uses the docs-domain route (\`docs.tenstorrent.com/tt-quietbox2-guide/\`), which per the AGENTS.md routing map reverse-proxies the guide repo's GitHub Pages. Worth confirming the proxy route is live for this new repo before merge.
- **Ask AI / kapa.ai:** adding the handbook to \`llms.txt\` aids discovery but does **not** register the site with kapa. The new path needs to be in kapa's configured crawl scope/sitemap (or added as a source) in the kapa.ai dashboard, then re-indexed, for it to appear in Ask AI answers.