### PR TITLE
feat(nav): add TT-XLA link to Software dropdown

### DIFF
--- a/core/_static/assets/svg/tt-xla.svg
+++ b/core/_static/assets/svg/tt-xla.svg
@@ -1,0 +1,10 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="4" y="4" width="12" height="12" fill="#57A773"/>
+<rect x="18" y="18" width="12" height="12" fill="#57A773"/>
+<rect x="32" y="32" width="12" height="12" fill="#57A773"/>
+<rect x="46" y="46" width="12" height="12" fill="#57A773"/>
+<rect x="46" y="4" width="12" height="12" fill="#57A773"/>
+<rect x="32" y="18" width="12" height="12" fill="#57A773"/>
+<rect x="18" y="32" width="12" height="12" fill="#57A773"/>
+<rect x="4" y="46" width="12" height="12" fill="#57A773"/>
+</svg>

--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -639,6 +639,13 @@
             </div>
             <p class="card-desc">End-to-end MLIR compiler. Compile models from PyTorch, JAX, and ONNX.</p>
           </a>
+          <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener" class="card">
+            <div class="card-head">
+              <img class="card-icon" src="_static/svg/tt-xla.svg" alt="TT-XLA" />
+              <p class="card-title">TT-XLA</p>
+            </div>
+            <p class="card-desc">PJRT-based frontend for running JAX and OpenXLA models on Tenstorrent hardware.</p>
+          </a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/ttnn/" target="_blank" rel="noopener" class="card">
             <div class="card-head">
               <img class="card-icon" src="_static/svg/tt-nn.svg" alt="TT-NN™" />

--- a/core/forge/index.rst
+++ b/core/forge/index.rst
@@ -18,10 +18,13 @@ Demos
 Compiler Stack
 --------------
 
+.. rst-class:: toctree-no-underline
+
+* `TT-XLA <https://docs.tenstorrent.com/tt-xla/>`_
+
 .. toctree::
    :maxdepth: 1
 
-   TT-XLA <https://docs.tenstorrent.com/tt-xla/>
    TT-Forge-ONNX <https://docs.tenstorrent.com/tt-forge-onnx/>
    TT-Blacksmith <https://docs.tenstorrent.com/tt-blacksmith/>
 

--- a/core/index.rst
+++ b/core/index.rst
@@ -31,6 +31,7 @@ Tenstorrent
 
    Overview <software/index>
    forge/index
+   TT-XLA <https://docs.tenstorrent.com/tt-xla/>
    TT-NN™ <https://docs.tenstorrent.com/tt-metal/latest/ttnn/>
    TT-Lang™ <https://docs.tenstorrent.com/tt-lang/>
    TT-MLIR™ <https://docs.tenstorrent.com/tt-mlir/>

--- a/core/software/index.rst
+++ b/core/software/index.rst
@@ -15,6 +15,13 @@ the lower layers are available when you need finer control.
          <span class="tt-doc-card-desc">End-to-end MLIR compiler. Compile models from PyTorch, JAX, and ONNX — the recommended entry point.</span>
        </span>
      </a>
+     <a class="tt-doc-card" href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">
+       <span class="tt-doc-card-img"><img src="../_static/svg/tt-xla.svg" alt="TT-XLA" /></span>
+       <span class="tt-doc-card-text">
+         <span class="tt-doc-card-title">TT-XLA</span>
+         <span class="tt-doc-card-desc">PJRT-based frontend for running JAX and OpenXLA models on Tenstorrent hardware.</span>
+       </span>
+     </a>
      <a class="tt-doc-card" href="https://docs.tenstorrent.com/tt-metal/latest/ttnn/" target="_blank" rel="noopener">
        <span class="tt-doc-card-img"><img src="../_static/svg/tt-nn.svg" alt="TT-NN" /></span>
        <span class="tt-doc-card-text">

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -49,10 +49,10 @@
         <a href="{{ _home }}#software">Software</a>
         <div class="tt-nav-dropdown">
           <a href="{{ _home }}forge/index.html">TT-Forge</a>
+          <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/ttnn/" target="_blank" rel="noopener">TT-NN</a>
           <a href="https://docs.tenstorrent.com/tt-lang/" target="_blank" rel="noopener">TT-Lang</a>
           <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
-          <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
           <a href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener">Cloud-Native Support</a>
         </div>

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -52,6 +52,7 @@
           <a href="https://docs.tenstorrent.com/tt-metal/latest/ttnn/" target="_blank" rel="noopener">TT-NN</a>
           <a href="https://docs.tenstorrent.com/tt-lang/" target="_blank" rel="noopener">TT-Lang</a>
           <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
+          <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
           <a href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener">Cloud-Native Support</a>
         </div>


### PR DESCRIPTION
## Summary
The top-nav **Software** dropdown was missing a **TT-XLA** entry (it lists TT-Forge, TT-NN, TT-Lang, TT-MLIR, TT-Metalium). Added TT-XLA, pointing to its docs site and matching the existing link style.

## Change
- `shared/_templates/layout.html` — add `<a href="https://docs.tenstorrent.com/tt-xla/">TT-XLA</a>`, placed after TT-MLIR (grouped with the other compiler frontends).