### PR TITLE
Add TT-Studio to the Software section

### DIFF
--- a/core/_static/assets/svg/tt-studio.svg
+++ b/core/_static/assets/svg/tt-studio.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 12H56V52H8V12ZM12 24V48H52V24H12Z" fill="#3AA6A0"/>
+<path d="M26 30L42 38L26 46V30Z" fill="#3AA6A0"/>
+</svg>

--- a/core/index.rst
+++ b/core/index.rst
@@ -37,6 +37,7 @@ Tenstorrent
    TT-MLIR™ <https://docs.tenstorrent.com/tt-mlir/>
    TT-Metalium™ <https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/>
    Cloud-Native Support <https://docs.tenstorrent.com/cloud-native-support/>
+   TT-Studio <https://docs.tenstorrent.com/tt-studio/>
    tools/index
 
 .. toctree::

--- a/core/software/index.rst
+++ b/core/software/index.rst
@@ -57,6 +57,13 @@ the lower layers are available when you need finer control.
          <span class="tt-doc-card-desc">Run Tenstorrent accelerators on Kubernetes — install, configure, and operate the device stack.</span>
        </span>
      </a>
+     <a class="tt-doc-card" href="https://docs.tenstorrent.com/tt-studio/" target="_blank" rel="noopener">
+       <span class="tt-doc-card-img"><img src="../_static/svg/tt-studio.svg" alt="TT-Studio" /></span>
+       <span class="tt-doc-card-text">
+         <span class="tt-doc-card-title">TT-Studio</span>
+         <span class="tt-doc-card-desc">Point-and-click web GUI to deploy, chat with, and build on models — a browser front-end over TT-Inference-Server.</span>
+       </span>
+     </a>
    </div>
 
 Choosing your entry point


### PR DESCRIPTION
## What this does

Surfaces TT-Studio alongside the other software products in the docs, matching
how TT-XLA, TT-Metalium, Cloud-Native Support, etc. are presented.

- **Software left-nav** (`core/index.rst`): adds a `TT-Studio` entry linking to
  `https://docs.tenstorrent.com/tt-studio/`, placed after Cloud-Native Support
  and before Tools. It renders as an external link with the new-tab glyph, the
  same as the other external Software entries.
- **Software overview grid** (`core/software/index.rst`): adds a TT-Studio card
  mirroring the existing cards, with a short description.
- **Icon** (`core/_static/assets/svg/tt-studio.svg`): a new flat 64×64 glyph in
  the same style as the other product icons.

## Verification

Docs-only change — app endpoints are N/A. Built the core site locally
(`homepage=/ sphinx-build -b html core core/_build/html`); the build succeeds
with no new warnings. Confirmed TT-Studio appears in the Software sidebar in
the correct position, the overview card renders with its icon, and the icon is
copied to the output at `_static/svg/tt-studio.svg`.

Companion to the TT-Studio docs site itself (tenstorrent/tt-studio#1137), which
is what the new link points to.

Leaving the merge to a reviewer.