### PR TITLE
Add TT-Studio docs at docs.tenstorrent.com/tt-studio

### DIFF
--- a/core/_static/assets/svg/tt-studio.svg
+++ b/core/_static/assets/svg/tt-studio.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 12H56V52H8V12ZM12 24V48H52V24H12Z" fill="#3AA6A0"/>
+<path d="M26 30L42 38L26 46V30Z" fill="#3AA6A0"/>
+</svg>

--- a/core/index.rst
+++ b/core/index.rst
@@ -37,6 +37,7 @@ Tenstorrent
    TT-MLIR™ <https://docs.tenstorrent.com/tt-mlir/>
    TT-Metalium™ <https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/>
    Cloud-Native Support <https://docs.tenstorrent.com/cloud-native-support/>
+   TT-Studio <https://docs.tenstorrent.com/tt-studio/>
    tools/index
 
 .. toctree::

--- a/core/software/index.rst
+++ b/core/software/index.rst
@@ -57,6 +57,13 @@ the lower layers are available when you need finer control.
          <span class="tt-doc-card-desc">Run Tenstorrent accelerators on Kubernetes — install, configure, and operate the device stack.</span>
        </span>
      </a>
+     <a class="tt-doc-card" href="https://docs.tenstorrent.com/tt-studio/" target="_blank" rel="noopener">
+       <span class="tt-doc-card-img"><img src="../_static/svg/tt-studio.svg" alt="TT-Studio" /></span>
+       <span class="tt-doc-card-text">
+         <span class="tt-doc-card-title">TT-Studio</span>
+         <span class="tt-doc-card-desc">Point-and-click web GUI to deploy, chat with, and build on models — a browser front-end over TT-Inference-Server.</span>
+       </span>
+     </a>
    </div>
 
 Choosing your entry point

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -55,6 +55,7 @@
           <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
           <a href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener">Cloud-Native Support</a>
+          <a href="https://docs.tenstorrent.com/tt-studio/" target="_blank" rel="noopener">TT-Studio</a>
         </div>
       </li>
       <li class="has-dropdown">

--- a/tt-studio/Makefile
+++ b/tt-studio/Makefile
@@ -1,0 +1,56 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# Repo root (parent of this core/ directory) — for venv + shared theme watch
+THIS_MAKEFILE := $(lastword $(MAKEFILE_LIST))
+REPO_ROOT     := $(abspath $(dir $(THIS_MAKEFILE))..)
+VENV_PY       := $(REPO_ROOT)/.venv/bin/python
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+# Same layout as `make html` (sphinx -M html writes HTML under $(BUILDDIR)/html/).
+WEBROOT       = $(BUILDDIR)/html
+
+HOST          ?= 127.0.0.1
+PORT          ?= 3000
+SERVE_PORT    ?= 8766
+# Base URL the top-nav links are built from (conf.py reads the `homepage` env
+# var). CI sets this to the public base URL; locally the core build is served
+# at the server root, so default to "/". Without it the nav renders "None…"
+# links that 404.
+HOMEPAGE      ?= /
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Development (watch): sphinx-autobuild. Run from core/: cd core && make watch
+watch:
+	@test -x "$(VENV_PY)" || (echo "Missing $(VENV_PY) — run: cd \"$(REPO_ROOT)\" && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" >&2; exit 1)
+	@echo ""
+	@echo "Preview: http://$(HOST):$(PORT)/forge/index.html"
+	@echo ""
+	@homepage="$(HOMEPAGE)" "$(VENV_PY)" -m sphinx_autobuild "$(SOURCEDIR)" "$(WEBROOT)" $(SPHINXOPTS) $(O) \
+		--port $(PORT) --host $(HOST) \
+		--watch "$(REPO_ROOT)/shared" \
+		--watch "$(REPO_ROOT)/syseng"
+
+# One-shot HTML build + stdlib HTTP server (no live reload).
+serve:
+	@test -x "$(VENV_PY)" || (echo "Missing $(VENV_PY) — run: cd \"$(REPO_ROOT)\" && python3 -m venv .venv && .venv/bin/pip install -r requirements.txt" >&2; exit 1)
+	@homepage="$(HOMEPAGE)" "$(VENV_PY)" -m sphinx -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@echo ""
+	@echo "Serving: http://$(HOST):$(SERVE_PORT)/forge/index.html"
+	@echo ""
+	@cd "$(WEBROOT)" && "$(VENV_PY)" -m http.server $(SERVE_PORT) --bind $(HOST)
+
+.PHONY: help Makefile watch serve
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# `make mode` option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tt-studio/_static/mermaid-tweaks.css
+++ b/tt-studio/_static/mermaid-tweaks.css
@@ -1,0 +1,15 @@
+/* Present mermaid diagrams on a light, self-contained card so they read
+   cleanly against the docs theme (matching the reference wiki styling). */
+.mermaid {
+  background: #f7f7f8;
+  border: 1px solid #e3e3e6;
+  border-radius: 8px;
+  padding: 18px;
+  margin: 1.4em 0;
+  text-align: center;
+  overflow-x: auto;
+}
+.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}

--- a/tt-studio/agent/api-and-tools.md
+++ b/tt-studio/agent/api-and-tools.md
@@ -1,0 +1,127 @@
+# Agent API & Tool Integration
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx">app/frontend/src/components/chatui/MessageActions.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts">app/frontend/src/components/chatui/runInference.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts">app/frontend/src/components/chatui/types.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx">app/frontend/src/components/rag/RagManagement.tsx</a></li>
+</ul>
+</details>
+
+
+
+The AI Agent service (`tt_studio_agent`) provides an autonomous assistant capable of multi-step reasoning, tool execution, and real-time interaction. It exposes a FastAPI-based interface for the frontend to manage conversations and poll for agent updates.
+
+## API Architecture & Endpoints
+
+The agent service runs on port `8080` [app/docker-compose.yml:116](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L116) and uses FastAPI to handle incoming requests. It implements a polling-based architecture to manage long-running reasoning tasks and tool executions. The service is integrated into the `tt_studio_network` to communicate with the backend and local LLM containers [app/docker-compose.yml:113-114](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L113-L114).
+
+### Key Endpoints
+
+| Endpoint | Method | Description |
+| :--- | :--- | :--- |
+| `/agent/` | `POST` | Primary entry point for sending user messages to the agent. |
+| `/poll_requests` | `GET` | Used by the frontend to retrieve the latest state of an active agent reasoning chain. |
+| `/status` | `GET` | Health check endpoint returning the status of the agent service and connected LLMs. |
+
+### Data Flow: Frontend to Agent
+The frontend initiates communication via the `runInference` function [app/frontend/src/components/chatui/runInference.ts:18-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L18-L30). If `isAgentSelected` is true, the request is routed to the agent API instead of a standard inference endpoint [app/frontend/src/components/chatui/runInference.ts:181-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L181-L185).
+
+1.  **Request Initiation**: `runInference` constructs a request body containing the `threadId` and `messages` [app/frontend/src/components/chatui/runInference.ts:201-220](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L201-L220).
+2.  **Authentication**: Requests include a JWT Bearer token derived from the `VITE_LLAMA_AUTH_TOKEN` (which maps to the stack's `JWT_SECRET`) [app/frontend/src/components/chatui/runInference.ts:190-198](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L190-L198).
+3.  **Conversation Management**: The `thread_id` allows the agent to maintain state across multiple turns in a single session [app/frontend/src/components/chatui/runInference.ts:201](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L201).
+
+**Diagram: Agent API Communication Flow**
+```mermaid
+sequenceDiagram
+    participant FE as "ChatComponent (React)"
+    participant RI as "runInference.ts"
+    participant AG as "tt_studio_agent (FastAPI)"
+    participant LLM as "Local LLM Container"
+
+    FE->>RI: runInference(..., isAgentSelected=true)
+    RI->>AG: POST /models-api/agent/ (messages, thread_id)
+    AG-->>RI: 200 OK (Request Accepted)
+    loop Polling for Updates
+        RI->>AG: GET /poll_requests?thread_id=...
+        AG->>LLM: Generate Thought/Tool Call
+        LLM-->>AG: Tool Request (e.g. Search)
+        AG-->>RI: SSE/JSON (Current Thought + Tool Status)
+    end
+```
+Sources: [app/docker-compose.yml:106-137](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L137), [app/frontend/src/components/chatui/runInference.ts:181-220](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L181-L220)
+
+## Tool Integration
+
+The agent uses a ReAct (Reasoning and Acting) framework to interact with external tools. These tools allow the agent to perform actions beyond simple text generation.
+
+### Tavily Search Tool
+The agent integrates the **Tavily Search API** to perform real-time web searches. This enables the assistant to answer questions about current events or technical documentation not present in its training data.
+*   **Configuration**: Requires the `TAVILY_API_KEY` environment variable [app/docker-compose.yml:119](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L119).
+*   **Usage**: When the agent determines a search is necessary, it invokes the Tavily client, parses the results, and injects them back into its reasoning context.
+
+### Code Interpreter (E2B)
+The agent optionally integrates with **E2B (Engine for 2B)** to provide a sandboxed Python code execution environment.
+*   **Capabilities**: Allows the agent to write and execute Python code, perform data analysis, and generate charts.
+*   **Security**: Code is executed in an isolated cloud-based sandbox, preventing arbitrary execution on the host Tenstorrent machine.
+*   **Configuration**: Managed via the `E2B_API_KEY` environment variable [app/docker-compose.yml:128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L128).
+
+### LiteLLM Gateway for Coding Agents
+For advanced coding tasks (e.g., using Cursor or Claude Code), the system provides a `tt_studio_litellm` service [app/docker-compose.yml:138](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138).
+*   **Protocol Translation**: Bridges OpenAI and Anthropic surfaces to the local Django backend.
+*   **Dynamic Routing**: Routes requests to the backend API hostname defined in environment variables [app/docker-compose.yml:148-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L148-L150).
+*   **Security**: Uses `LITELLM_MASTER_KEY` for gateway access and `LITELLM_UPSTREAM_KEY` for backend authentication [app/docker-compose.yml:149-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L149-L150).
+
+**Diagram: Tool & Gateway Entity Mapping**
+```mermaid
+graph TD
+    subgraph "Agent Service Space"
+        A["tt_studio_agent"] --> B{"Tool Selector"}
+        B -- "Web Search" --> C["TavilySearchResults"]
+        B -- "Run Code" --> D["E2BCodeInterpreter"]
+    end
+
+    subgraph "Coding Agent Gateway Space"
+        LIT["tt_studio_litellm (Port 4000)"] -- "LITELLM_UPSTREAM_KEY" --> BE["tt_studio_backend (Port 8000)"]
+        CLI["External IDE (Cursor/Claude)"] -- "OpenAI/Anthropic Protocol" --> LIT
+    end
+
+    subgraph "Backend Space"
+        BE -- "vLLM Bridge" --> INF["Local Inference Container"]
+    end
+```
+Sources: [app/docker-compose.yml:138-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138-L162), [app/frontend/src/components/chatui/runInference.ts:181-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L181-L185)
+
+## Conversation & State Management
+
+The agent maintains conversation history using a `thread_id` system, which ensures that multi-turn reasoning remains coherent.
+
+### Polling & Circuit Breaking
+To prevent infinite loops or stalled agents, the service implements polling configurations:
+*   `AGENT_LLM_POLLING_TIMEOUT`: Max time allowed for a single polling request [app/docker-compose.yml:125](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L125).
+*   `AGENT_LLM_POLLING_MAX_ATTEMPTS`: Max retries for agent reasoning steps [app/docker-compose.yml:126](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L126).
+*   `AGENT_LLM_POLLING_CIRCUIT_BREAKER_THRESHOLD`: Threshold to stop execution if the agent fails repeatedly [app/docker-compose.yml:127](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L127).
+
+### Session Identification
+A unique `X-Browser-ID` is generated by the frontend to ensure that RAG collections and agent sessions are correctly associated with specific browser instances [app/frontend/src/components/rag/RagManagement.tsx:67-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L67-L76). This ID is added to the headers of all fetch requests [app/frontend/src/components/rag/RagManagement.tsx:79-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L79-L97).
+
+### Message Actions & UI
+The UI provides specific actions for agent-generated messages, including a "Thinking" toggle to visualize the agent's internal reasoning process [app/frontend/src/components/chatui/MessageActions.tsx:154-175](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L154-L175).
+
+## Environment Configuration
+
+The agent's behavior and tool access are governed by environment variables defined in the `.env` file and passed to the container via `docker-compose.yml`.
+
+| Variable | Description | Source |
+| :--- | :--- | :--- |
+| `TAVILY_API_KEY` | API key for web search capabilities. | [app/docker-compose.yml:119](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L119) |
+| `E2B_API_KEY` | API key for the sandboxed Python code interpreter. | [app/docker-compose.yml:128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L128) |
+| `JWT_SECRET` | Secret used for JWT authentication between services. | [app/docker-compose.yml:118](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L118) |
+| `LITELLM_PORT` | Port for the coding agent gateway (default 4000). | [app/docker-compose.yml:146](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L146) |
+| `AGENT_LLM_POLLING_TIMEOUT` | Max time allowed for a single polling request. | [app/docker-compose.yml:125](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L125) |
+| `USE_CLOUD_LLM` | Toggle to use cloud-based models for the agent reasoning. | [app/docker-compose.yml:122](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L122) |
+
+Sources: [app/docker-compose.yml:116-130](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L116-L130), [app/frontend/src/components/rag/RagManagement.tsx:64-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L64-L97), [app/frontend/src/components/chatui/MessageActions.tsx:154-175](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L154-L175)27:T1c91,# Frontend Application

--- a/tt-studio/agent/architecture.md
+++ b/tt-studio/agent/architecture.md
@@ -1,0 +1,130 @@
+# Agent Architecture & LLM Discovery
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md">README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md">app/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html">app/frontend/index.html</a></li>
+</ul>
+</details>
+
+
+
+The AI Agent service (`tt_studio_agent`) is a specialized autonomous assistant designed to orchestrate complex tasks by leveraging local Tenstorrent-hosted LLMs. It utilizes a LangChain-based ReAct framework to interact with the system through tools while maintaining a resilient connection to inference containers via a dedicated discovery and health monitoring subsystem.
+
+## Core Agent Architecture
+
+The agent is built as a FastAPI service that wraps a LangChain ReAct agent. It operates on a "poll-and-process" model where it consumes requests from a queue, processes them using the available LLM, and streams responses back to the frontend. The service is containerized and depends on the `tt_studio_backend` for its initial state and network configuration [app/docker-compose.yml:106-114](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L114).
+
+### Component Overview
+The architecture is divided into three main layers:
+1.  **API Layer**: FastAPI endpoints (port 8080) that handle incoming chat requests via `/poll_requests` and status checks [app/docker-compose.yml:115-116](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L115-L116).
+2.  **Agent Logic Layer**: The ReAct executor and `CustomLLM` wrapper which handles the reasoning loop and tool selection.
+3.  **Infrastructure Layer**: Discovery services and health monitors that maintain the link to hardware-accelerated LLM containers.
+
+### System Data Flow: From Request to Execution
+The following diagram illustrates how a user request flows through the agent service and how it interacts with the underlying LLM infrastructure.
+
+**Agent Inference & Tool Execution Flow**
+```mermaid
+sequenceDiagram
+    participant FE as "ChatComponent [app/frontend/src/components/chatui/ChatComponent.tsx]"
+    participant AG as "AgentService [tt_studio_agent/main.py]"
+    participant LC as "ReActExecutor [LangChain]"
+    participant LLM as "CustomLLM [tt_studio_agent/llm_discovery.py]"
+    participant INF as "InferenceContainer [tt-inference-server]"
+
+    FE->>AG: POST /poll_requests (thread_id, text)
+    AG->>LC: execute(prompt)
+    LC->>LLM: invoke(messages)
+    LLM->>INF: POST /v1/chat/completions (OpenAI API)
+    INF-->>LLM: Response Stream
+    LLM-->>LC: Parsed Thought/Action
+    alt Action Required
+        LC->>AG: Call Tool (e.g., Tavily, Python)
+        AG-->>LC: Tool Output
+        LC->>LLM: invoke(context + tool_output)
+    end
+    LC-->>AG: Final Answer
+    AG-->>FE: SSE Stream (tokens)
+```
+Sources: [app/docker-compose.yml:106-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L128).
+
+## LLM Discovery & Health Monitoring
+
+The agent service does not have a hardcoded LLM endpoint. Instead, it dynamically discovers available local inference containers using the `LLMDiscoveryService`.
+
+### LLMDiscoveryService
+This service scans the Docker network for containers that expose compatible inference APIs. It prioritizes local Tenstorrent-hosted models over cloud fallbacks.
+
+*   **Detection Logic**: It queries the `docker-control-service` or scans the environment for active deployments tracked in the `ModelDeployment` store.
+*   **CustomLLM Wrapper**: Implements the LangChain `BaseLLM` interface, allowing the agent to treat local FastAPI inference servers as standard LangChain LLMs.
+
+### LiteLLM Gateway Integration
+For external coding assistants (like Cursor or Claude Code) to interact with local Tenstorrent models, a `tt_studio_litellm` gateway is used as a protocol translation layer. It maps OpenAI and Anthropic API surfaces to the TT-Studio backend [app/docker-compose.yml:138-142](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138-L142).
+
+*   **Upstream Routing**: The gateway routes all incoming model requests to the Django backend's OpenAI-compatible endpoint.
+*   **Master Key Security**: Access is protected via the `LITELLM_MASTER_KEY` [app/docker-compose.yml:148-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L148-L150).
+*   **Persistent Configuration**: Uses a `config.yaml` volume mount to define model mappings and proxy settings [app/docker-compose.yml:151-152](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L151-L152).
+
+### LLMHealthMonitor
+To ensure high availability, the system continuously polls the discovered endpoints.
+*   **Polling**: It verifies that containers are still in a `service_healthy` state before routing traffic [app/docker-compose.yml:157-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L157-L162).
+*   **ChromaDB Health**: The backend ensures the vector store is healthy before initializing RAG-dependent agent tools [app/docker-compose.yml:25-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L25-L27).
+*   **Backend Readiness**: The agent service itself waits for the `tt_studio_backend` to pass its healthcheck before starting its polling loop [app/docker-compose.yml:110-112](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L110-L112).
+
+| Component | Responsibility | Port |
+| :--- | :--- | :--- |
+| **Discovery** | Detects local `tt-inference-server` instances via Docker network. | N/A |
+| **LiteLLM** | Provides OpenAI surface for external tools [app/docker-compose.yml:146-146](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L146-L146). | 4000 |
+| **Agent API** | Handles chat requests and tool orchestration [app/docker-compose.yml:115-116](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L115-L116). | 8080 |
+| **Backend API** | Manages model deployment lifecycle and health state [app/docker-compose.yml:21-22](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L21-L22). | 8000 |
+
+Sources: [app/docker-compose.yml:21-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L21-L162).
+
+## LLM Integration & Natural Language Space
+
+The agent acts as the bridge between the user's natural language intent and the "Code Entity Space" of the TT-Studio system. It uses the `CustomLLM` to translate these intents into structured tool calls.
+
+**Natural Language to Code Entity Mapping**
+```mermaid
+graph TD
+    subgraph "Natural Language Space"
+        UserQuery["'Check the status of my Grayskull chip'"]
+    end
+
+    subgraph "Agent Logic (tt_studio_agent)"
+        Agent["ReAct Agent [tt_studio_agent]"]
+        LLMWrap["CustomLLM Wrapper [llm_discovery.py]"]
+    end
+
+    subgraph "Code Entity Space (Backend/Infrastructure)"
+        Tool1["tt_studio_backend health check [/up/]"]
+        Tool2["tt_studio_chroma heartbeat [/api/v1/heartbeat]"]
+        DB["ChromaDB [tt_studio_chroma]"]
+    end
+
+    UserQuery --> Agent
+    Agent --> LLMWrap
+    LLMWrap --> Agent
+    Agent -- "Action: Call Health API" --> Tool1
+    Agent -- "Action: Query Vector DB" --> DB
+    Tool1 -- "Checks" --> Tool2
+```
+Sources: [app/docker-compose.yml:80-87](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L80-L87), [app/docker-compose.yml:180-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L180-L185).
+
+## Multi-LLM Fallback Logic
+
+The agent service is designed to be resilient. If the primary high-performance model is not available or the hardware is over-subscribed, it follows a hierarchical fallback strategy:
+
+1.  **Local High-Perf**: Attempts to connect to a local container as specified by `LLM_CONTAINER_NAME` [app/docker-compose.yml:123-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L123-L123).
+2.  **Cloud Bridge**: If `USE_CLOUD_LLM` is set to `true`, it routes requests to a remote inference cloud (e.g., via `CLOUD_CHAT_UI_URL`) [app/docker-compose.yml:120-122](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L120-L122).
+3.  **Circuit Breaker**: The polling mechanism uses `AGENT_LLM_POLLING_CIRCUIT_BREAKER_THRESHOLD` to stop attempts if the LLM is consistently unreachable [app/docker-compose.yml:127-127](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L127-L127).
+
+### Implementation Details
+*   **Endpoint Resolution**: The API URL is determined dynamically at runtime based on the `BACKEND_API_HOSTNAME` [app/docker-compose.yml:124-124](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L124-L124).
+*   **Polling Configuration**: Retry logic is governed by `AGENT_LLM_POLLING_MAX_ATTEMPTS` and `AGENT_LLM_POLLING_TIMEOUT` [app/docker-compose.yml:125-126](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L125-L126).
+
+Sources: [app/docker-compose.yml:117-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L117-L128).26:T1fe8,# Agent API & Tool Integration

--- a/tt-studio/agent/index.md
+++ b/tt-studio/agent/index.md
@@ -1,0 +1,111 @@
+# AI Agent Service
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md">README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md">app/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html">app/frontend/index.html</a></li>
+</ul>
+</details>
+
+
+
+The `tt_studio_agent` service (operating on port `8080`) is an autonomous AI assistant subsystem within TT-Studio. It provides a high-level reasoning interface that can discover locally deployed LLMs, monitor their health, and execute complex tasks using a suite of integrated tools, including web search and secure code execution. [app/docker-compose.yml:106-116](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L116)
+
+## Overview
+
+The agent service acts as a bridge between natural language user intent and the technical capabilities of the TT-Studio ecosystem. Unlike standard inference routes that provide direct model access, the agent service manages stateful conversations and selects the best available local model to fulfill requests. [app/README.md:15-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L15-L15)
+
+### Key Capabilities
+*   **LLM Discovery & Fallback**: Automatically identifies available LLM containers on the `tt_studio_network` and maintains a priority-based fallback list. [app/docker-compose.yml:113-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L113-L123)
+*   **Health Monitoring**: Continuously polls inference endpoints to ensure the agent only routes traffic to responsive models. [app/docker-compose.yml:125-127](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L125-L127)
+*   **Tool Integration**: Extends LLM capabilities with a Tavily-powered web search and an optional E2B code interpreter for executing Python code in isolated environments. [app/docker-compose.yml:119-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L119-L128)
+*   **Conversation Management**: Uses `thread_id` to maintain context across multiple turns in a chat session.
+
+### Service Interaction Map
+The following diagram illustrates how the `tt_studio_agent` interacts with other system components and how it maps natural language requests to code-level execution entities.
+
+**Agent Service Integration Flow**
+```mermaid
+graph TD
+    User["User (Frontend)"] -- "POST /models-api/agent/" --> AgentAPI["tt_studio_agent (FastAPI)"]
+    
+    subgraph "Agent Internal Logic"
+        AgentAPI -- "manages" --> ThreadMgr["Thread Management (thread_id)"]
+        AgentAPI -- "invokes" --> ReAct["LangChain ReAct Agent"]
+        ReAct -- "checks" --> Discovery["LLMDiscoveryService"]
+        ReAct -- "executes" --> Tools["Tool Executor"]
+    end
+
+    subgraph "External & Local Services"
+        Discovery -- "polls" --> DeployedLLMs["Local LLM Containers (Port 8000)"]
+        Tools -- "API Call" --> Tavily["Tavily Search API"]
+        Tools -- "Sandbox" --> E2B["E2B Code Interpreter"]
+    end
+
+    DeployedLLMs -- "SSE Stream" --> AgentAPI
+    AgentAPI -- "SSE Stream" --> User
+```
+Sources: [app/docker-compose.yml:106-124](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L124), [app/README.md:15-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L15-L15)
+
+---
+
+## [Agent Architecture & LLM Discovery](architecture.md)
+
+The core of the service is built on a **LangChain-based ReAct (Reasoning and Acting) architecture**. It utilizes a `CustomLLM` wrapper to standardize communication with various local inference servers (e.g., vLLM or TGI-based containers).
+
+The **LLMDiscoveryService** is responsible for scanning the Docker environment to find containers that match known LLM signatures. It works in tandem with the **LLMHealthMonitor**, which performs periodic heartbeats. If the primary high-performance model becomes unresponsive, the agent utilizes polling timeouts and circuit breaker thresholds to manage fallbacks. [app/docker-compose.yml:125-127](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L125-L127)
+
+For details, see [Agent Architecture & LLM Discovery](architecture.md).
+
+**Natural Language to Code Entity Mapping: Discovery**
+```mermaid
+graph LR
+    subgraph "Natural Language Space"
+        Req["'Use the best available model'"]
+    end
+
+    subgraph "Code Entity Space"
+        Discovery["LLMDiscoveryService"]
+        Monitor["LLMHealthMonitor"]
+        Fallback["AGENT_LLM_POLLING_MAX_ATTEMPTS"]
+        Circuit["AGENT_LLM_POLLING_CIRCUIT_BREAKER_THRESHOLD"]
+        
+        Discovery --> Monitor
+        Monitor --> Fallback
+        Monitor --> Circuit
+    end
+
+    Req -.-> Discovery
+```
+Sources: [app/docker-compose.yml:125-127](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L125-L127)
+
+---
+
+## [Agent API & Tool Integration](api-and-tools.md)
+
+The agent exposes a FastAPI-based REST interface. Authentication is handled via **JWT (JSON Web Tokens)** to ensure secure access to tool execution and backend communication. [app/docker-compose.yml:118-118](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L118-L118)
+
+### Integrated Tools
+| Tool Name | Code Reference | Description |
+| :--- | :--- | :--- |
+| **Tavily Search** | `TAVILY_API_KEY` | Provides real-time web search capabilities to ground agent responses in current data. [app/docker-compose.yml:119-119](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L119-L119) |
+| **E2B Interpreter** | `E2B_API_KEY` | An optional tool for executing Python code in a secure sandbox. [app/docker-compose.yml:128-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L128-L128) |
+| **Cloud Fallback** | `USE_CLOUD_LLM` | Allows the agent to route queries to cloud providers if local resources are unavailable. [app/docker-compose.yml:122-122](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L122-L122) |
+
+The service is configured via environment variables to communicate with the `tt_studio_backend` via `BACKEND_API_HOSTNAME` and manage specific container targets via `LLM_CONTAINER_NAME`. [app/docker-compose.yml:123-124](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L123-L124)
+
+For details, see [Agent API & Tool Integration](api-and-tools.md).
+
+Sources: [app/docker-compose.yml:117-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L117-L128), [app/README.md:15-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L15-L15)25:T1d09,# Agent Architecture & LLM Discovery
+
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+architecture
+api-and-tools
+```

--- a/tt-studio/backend/board-control.md
+++ b/tt-studio/backend/board-control.md
@@ -1,0 +1,153 @@
+# Board Control & Hardware Monitoring
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py">app/backend/board_control/services.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx">app/frontend/src/components/Footer.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx">app/frontend/src/components/imageGen/StableDiffusionChat.tsx</a></li>
+</ul>
+</details>
+
+
+
+The `board_control` app is responsible for hardware detection, system resource monitoring, and providing real-time telemetry for Tenstorrent devices. It serves as the bridge between the physical hardware and the UI, ensuring that users are informed of chip availability, thermal status, and system-level bottlenecks (CPU/RAM).
+
+## System Architecture & Data Flow
+
+Hardware monitoring in TT-Studio follows a polling architecture where the frontend periodically requests system and device state. The data is aggregated from host-level utilities (for CPU/RAM) and Tenstorrent-specific drivers via `tt-smi` (for chip telemetry).
+
+### Data Aggregation Flow
+
+The following diagram illustrates how hardware data flows from the physical silicon to the `Footer.tsx` and `ChipStatusDisplay.tsx` components.
+
+**Hardware Telemetry Flow**
+```mermaid
+graph TD
+    subgraph "Hardware_Layer"
+        HW_ASIC["Tenstorrent ASIC (N150/N300/T3K)"]
+        HW_HOST["Host CPU & RAM"]
+    end
+
+    subgraph "Backend_Django"
+        BC_SRV["SystemResourceService"]
+        FOOTER_API["/board-api/footer-data/"]
+        CHIP_API["/docker-api/chip-status/"]
+    end
+
+    subgraph "Frontend_React"
+        DS_CTX["DeviceStateContext"]
+        FOOTER_COMP["Footer.tsx"]
+        CHIP_DISP["ChipStatusDisplay.tsx"]
+    end
+
+    HW_HOST -->|psutil| FOOTER_API
+    HW_ASIC -->|tt-smi -s| BC_SRV
+    BC_SRV -->|get_tt_smi_data| CHIP_API
+    FOOTER_API -->|fetchSystemResources| FOOTER_COMP
+    CHIP_API -->|axios| DS_CTX
+    DS_CTX -->|deviceState| CHIP_DISP
+    DS_CTX -->|deviceState| FOOTER_COMP
+```
+**Sources:** [app/backend/board_control/services.py:20-132](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L20-L132), [app/frontend/src/components/Footer.tsx:74-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L74-L99), [app/frontend/src/components/ChipStatusDisplay.tsx:97-103](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L97-L103)
+
+---
+
+## Core Components
+
+### 1. System Resource Service (`services.py`)
+The `SystemResourceService` class is the primary backend logic provider for hardware monitoring [app/backend/board_control/services.py:20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L20).
+
+*   **Telemetry Acquisition:** Uses `subprocess.Popen` to execute `tt-smi -s` and parse the resulting JSON output [app/backend/board_control/services.py:65-132](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L65-L132).
+*   **Caching Strategy:** Implements Django-based caching for `tt-smi` data (`TT_SMI_CACHE_KEY`) and board type (`BOARD_TYPE_CACHE_KEY`) to minimize expensive CLI calls [app/backend/board_control/services.py:23-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L23-L31).
+*   **Reset Monitoring:** Detects if a hardware reset is in progress by checking for a `reset_all_status.json` file in the backend cache root via `_board_reset_job_active` or a specific cache key `DEVICE_RESETTING_KEY` [app/backend/board_control/services.py:31-62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L31-L62).
+*   **Board Type Detection:** Identifies the hardware configuration (e.g., Galaxy, Nebula) by inspecting `board_info` in the `tt-smi` data and validating homogeneity across chips [app/backend/board_control/services.py:134-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L134-L162).
+
+### 2. Footer Telemetry (`Footer.tsx`)
+The `Footer` component acts as a persistent status bar. It aggregates high-level system metrics and hardware health alerts [app/frontend/src/components/Footer.tsx:38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L38).
+
+*   **System Resources:** Fetches CPU usage, memory usage, and total memory via the `fetchSystemResources` function which calls the `/board-api/footer-data/` endpoint [app/frontend/src/components/Footer.tsx:74-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L74-L99).
+*   **Board State:** Derives board name, state, and average temperature from the `DeviceStateContext` [app/frontend/src/components/Footer.tsx:178-188](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L178-L188).
+*   **Health Alerts:** Detects `BAD_STATE` or `NOT_PRESENT` statuses to trigger hardware error UI states [app/frontend/src/components/Footer.tsx:189-195](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L189-L195).
+*   **Manual Refresh:** Provides a `handleRefreshBoardDetection` function with a 2-minute cooldown (`REFRESH_COOLDOWN_MS`) to trigger a re-poll of the hardware state via `refreshDeviceState()` [app/frontend/src/components/Footer.tsx:101-126](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L101-L126).
+
+### 3. Chip Configuration & Status
+The system monitors chip availability to prevent resource contention during model deployment.
+
+*   **Chip Status Polling:** Components consume `deviceState` which provides real-time updates on chip occupancy and temperature [app/frontend/src/components/Footer.tsx:56-58](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L56-L58).
+*   **Slot Management:** The `ChipSlot` interface tracks whether a slot is `available` or `occupied`, its `slot_id`, and identifies if a chip is part of a `is_multi_chip` deployment [app/frontend/src/components/ChipStatusDisplay.tsx:7-13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L7-L13).
+*   **Board Grouping:** Certain boards like `P300x2` and `P300Cx4` group chips into physical cards. The `ChipStatusDisplay` handles this using the `CARD_GROUPINGS` constant to map chips to their respective card labels [app/frontend/src/components/ChipStatusDisplay.tsx:24-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L24-L27).
+
+---
+
+## Hardware Detection Logic
+
+The application categorizes hardware based on the detected board type, which influences the UI layout and grouping.
+
+| Board Type | Chips Per Card | Card Label |
+| :--- | :--- | :--- |
+| **P300x2** | 2 | P300 Card |
+| **P300Cx4** | 2 | P300 Card |
+| **Default** | Flat Layout | N/A |
+
+**Sources:** [app/frontend/src/components/ChipStatusDisplay.tsx:24-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L24-L27), [app/frontend/src/components/ChipStatusDisplay.tsx:137-180](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L137-L180)
+
+---
+
+## Implementation Details
+
+### Device State Context
+The `DeviceStateContext` is the primary source of truth for hardware health across the frontend. It provides the `deviceState` object which includes:
+*   `board_name`: The detected Tenstorrent board (e.g., "Galaxy", "Nebula").
+*   `state`: Current operational status (e.g., "ACTIVE", "BAD_STATE", "RESETTING").
+*   `devices`: An array of individual chip telemetry (temperature, `slot_id`).
+
+**Code Entity Relationship**
+```mermaid
+classDiagram
+    class SystemResourceService {
+        +get_tt_smi_data()
+        +get_board_type()
+        +is_reset_in_progress()
+    }
+    class DeviceStateContext {
+        +deviceState: DeviceState
+        +refresh()
+    }
+    class DeviceState {
+        +board_name: string
+        +state: string
+        +devices: Device[]
+    }
+    class Device {
+        +slot_id: number
+        +temperature: number
+        +status: string
+    }
+    class Footer {
+        +fetchSystemResources()
+        +handleRefreshBoardDetection()
+    }
+    class ChipStatusDisplay {
+        +slots: ChipSlot[]
+        +hasConnector(index)
+    }
+    
+    Footer ..> DeviceStateContext : "consumes via useDeviceState"
+    ChipStatusDisplay ..> DeviceStateContext : "consumes via props"
+    DeviceStateContext ..> SystemResourceService : "indirectly via board-api"
+    DeviceStateContext *-- DeviceState
+    DeviceState *-- Device
+```
+**Sources:** [app/backend/board_control/services.py:20-132](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/board_control/services.py#L20-L132), [app/frontend/src/components/Footer.tsx:56-58](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L56-L58), [app/frontend/src/components/Footer.tsx:178-188](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L178-L188), [app/frontend/src/components/ChipStatusDisplay.tsx:7-13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L7-L13)
+
+### Manual Re-detection
+When hardware is not detected correctly or a "BAD_STATE" is encountered, the `Footer` component allows users to trigger a refresh. This calls `refreshDeviceState()` from the context, which initiates a new backend scan of the PCIe bus and Tenstorrent drivers [app/frontend/src/components/Footer.tsx:109-126](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx#L109-L126).
+
+### Visualizing Occupancy
+The `ChipStatusDisplay` component visualizes the physical layout of the chips. If two adjacent chips are occupied and marked as `is_multi_chip`, it renders a "connector" line using the `hasConnector` function to indicate they are logically linked for a single model deployment [app/frontend/src/components/ChipStatusDisplay.tsx:108-118](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipStatusDisplay.tsx#L108-L118).
+
+**Sources:**
+- `app/backend/board_control/services.py`
+- `app/frontend/src/components/Footer.tsx`
+- `app/frontend/src/components/ChipStatusDisplay.tsx`20:T205a,# Logs Control & Bug Reporting

--- a/tt-studio/backend/docker-control.md
+++ b/tt-studio/backend/docker-control.md
@@ -1,0 +1,146 @@
+# Docker Control & Container Lifecycle
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/apps.py">app/backend/docker_control/apps.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py">app/backend/docker_control/chip_allocator.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_store.py">app/backend/docker_control/deployment_store.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py">app/backend/docker_control/docker_utils.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py">app/backend/docker_control/health_monitor.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/serializers.py">app/backend/docker_control/serializers.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tests.py">app/backend/docker_control/tests.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py">app/backend/docker_control/tt_inference_client.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/urls.py">app/backend/docker_control/urls.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/views.py">app/backend/docker_control/views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py">app/backend/model_control/model_utils.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/views.py">app/backend/model_control/views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx">app/frontend/src/components/FirstStepForm.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py">docker-control-service/api.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py">inference-api/api.py</a></li>
+</ul>
+</details>
+
+
+
+The `docker_control` Django app is the core orchestration engine for managing AI model containers within TT-Studio. It manages the full lifecycle of inference containers—from hardware capability detection and chip slot allocation to deployment via the `inference-api` and continuous health monitoring.
+
+## Architecture & Data Flow
+
+The system operates as a bridge between the user-facing Django backend and the hardware-level Docker operations. To maintain security and avoid mounting the Docker socket directly into the web-facing container, all Docker commands are proxied through the `docker-control-service`.
+
+### Deployment Orchestration Flow
+
+This diagram illustrates the flow from a frontend deployment request to a running model container, highlighting the code entities involved in the transition.
+
+"Deployment Orchestration Flow"
+```mermaid
+sequenceDiagram
+    participant FE as "Frontend (FirstStepForm.tsx)"
+    participant DCV as "docker_control.views.DeployView"
+    participant CSA as "docker_control.chip_allocator.ChipSlotAllocator"
+    participant TIC as "docker_control.tt_inference_client.start_chat_deployment"
+    participant IAPI as "inference-api (api.py :8001)"
+    participant DCS as "docker-control-service (api.py :8002)"
+
+    FE->>DCV: POST /api/docker/deploy/
+    DCV->>CSA: allocate_chip_slot(model_name)
+    CSA-->>DCV: device_id (e.g. 0)
+    
+    DCV->>TIC: start_chat_deployment(model_name, device, device_id)
+    TIC->>IAPI: POST /run (Payload: model, device, device_id)
+    IAPI-->>TIC: job_id (202 Accepted)
+    TIC-->>DCV: TTInferenceRunResult(job_id)
+    DCV-->>FE: {"status": "success", "job_id": "..."}
+    
+    Note over IAPI,DCS: Background: IAPI run_main() calls DCS /containers/run
+```
+Sources: [app/backend/docker_control/views.py:334-450](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/views.py#L334-L450), [app/backend/docker_control/tt_inference_client.py:84-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L167), [app/backend/docker_control/chip_allocator.py:164-197](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py#L164-L197), [inference-api/api.py:163-250](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L163-L250)
+
+## Deployment Store (JSON ORM)
+
+TT-Studio uses a thread-safe JSON-backed store instead of a traditional Django SQLite database for deployment metadata. This ensures that deployment state persists across backend container restarts without requiring complex database migrations.
+
+The `ModelDeployment` class in `deployment_store.py` provides a drop-in ORM-like interface:
+*   **Location**: Determined by `backend_config.backend_cache_root`, typically within the persistent volume at `tenstorrent/deployments.json` [app/backend/docker_control/deployment_store.py:23-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_store.py#L23-L27).
+*   **Managers**: Implements `objects.create()`, `objects.filter()`, and `objects.all()` using a `DeploymentManager` [app/backend/docker_control/deployment_store.py:178-216](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_store.py#L178-L216).
+*   **Concurrency**: Uses `threading.Lock()` to prevent race conditions during file I/O [app/backend/docker_control/deployment_store.py:29-29](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_store.py#L29-L29).
+*   **Normalization**: Automatically handles `device_ids` (multi-chip) vs `device_id` (single-chip) fields to support various board topologies [app/backend/docker_control/deployment_store.py:53-85](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_store.py#L53-L85).
+
+Sources: [app/backend/docker_control/deployment_store.py:5-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_store.py#L5-L30), [app/backend/docker_control/models.py:1-20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/models.py#L1-L20)
+
+## Chip Slot Allocation
+
+The `ChipSlotAllocator` manages the mapping between Tenstorrent hardware (chips) and model containers. It prevents resource over-subscription by tracking which `slot_id` is currently occupied.
+
+| Feature | Description |
+| :--- | :--- |
+| **Board Detection** | Uses `detect_board_type()` to identify installed hardware via `tt-smi` [app/backend/docker_control/chip_allocator.py:85-88](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py#L85-L88). |
+| **Slot Count** | Maps board types to total available slots (e.g., Galaxy=32, T3K=4, P150X8=8) [app/backend/docker_control/chip_allocator.py:54-65](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py#L54-L65). |
+| **Multi-Chip Support** | Models requiring 4 chips (e.g. Llama-3-70B) occupy all slots on a 4-chip card [app/backend/docker_control/chip_allocator.py:123-131](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py#L123-L131). |
+| **Validation** | `_validate_manual_allocation` ensures a user-selected chip is not already occupied [app/backend/docker_control/chip_allocator.py:183-189](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py#L183-L189). |
+
+Sources: [app/backend/docker_control/chip_allocator.py:70-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/chip_allocator.py#L70-L162), [app/backend/docker_control/docker_utils.py:135-168](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py#L135-L168)
+
+## Container Lifecycle Management
+
+### Health Monitoring
+The `health_monitor.py` module runs a background thread that polls the status of all containers marked as `running` in the `ModelDeployment` store every 5 seconds [app/backend/docker_control/health_monitor.py:131-154](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L131-L154).
+
+1.  **Unexpected Death Detection**: If `docker_client.get_container()` reports a status other than `running` or `restarting`, the database record is updated to the actual status (e.g., `exited`, `dead`) [app/backend/docker_control/health_monitor.py:93-110](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L93-L110).
+2.  **Stale Record Cleanup**: Cleans up `starting` records that fail to transition. `pending_*` records are purged after 10 minutes, while FastAPI `job_id` records are timed out after 35 minutes to allow for large weight downloads [app/backend/docker_control/health_monitor.py:19-73](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L19-L73).
+
+### Deployment Sync
+The `deployment_sync.py` module bridges the gap between the `inference-api`'s asynchronous `/run` jobs and the backend's deployment state. 
+
+*   **Polling**: It spawns a per-job daemon thread that polls the FastAPI `/run/progress/{job_id}` endpoint [app/backend/docker_control/deployment_sync.py:120-159](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L120-L159).
+*   **State Transition**: On `completed`, it swaps the `job_id` placeholder for the real Docker `container_id` and marks the status as `running` [app/backend/docker_control/deployment_sync.py:63-92](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L63-L92).
+*   **User Cancellation**: If a user stops a deployment while it is still in the `starting` phase, `_do_sync` ensures the container is cleaned up immediately upon completion [app/backend/docker_control/deployment_sync.py:68-82](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L68-L82).
+
+Sources: [app/backend/docker_control/health_monitor.py:76-130](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L76-L130), [app/backend/docker_control/deployment_sync.py:47-118](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L47-L118)
+
+## Integration Components
+
+### TT Inference Client
+The `tt_inference_client.py` is a specialized wrapper for the `inference-api`. Its primary function, `start_chat_deployment`, sends a standardized payload to the FastAPI service on port 8001.
+
+*   **Endpoint**: `http://172.18.0.1:8001/run` [app/backend/docker_control/tt_inference_client.py:90-90](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L90-L90).
+*   **Payload**: Includes `model`, `workflow`, `device`, `device_id`, and `dev_mode` flags [app/backend/docker_control/tt_inference_client.py:103-120](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L103-L120).
+
+### Docker Control Client
+The `DockerControlClient` communicates with the `docker-control-service` (port 8002) using JWT authentication [app/backend/docker_control/docker_control_client.py:43-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L43-L53). It replaces direct Docker SDK usage to ensure the backend container does not require `/var/run/docker.sock` access.
+
+"Docker Control Interface Mapping"
+```mermaid
+classDiagram
+    class "docker_control.docker_control_client.DockerControlClient" {
+        +list_containers(all, filters)
+        +run_container(image, name, ports, env)
+        +stop_container(container_id)
+        +get_container(container_id)
+    }
+    class "docker_control.views.ContainersView" {
+        +get(request)
+    }
+    class "docker_control.docker_utils" {
+        +_ensure_network()
+        +_run_direct_container(impl, weights_id)
+    }
+
+    "docker_control.views.ContainersView" ..> "docker_control.docker_control_client.DockerControlClient" : uses list_containers()
+    "docker_control.docker_utils" ..> "docker_control.docker_control_client.DockerControlClient" : uses get_docker_client()
+    "docker_control.health_monitor" ..> "docker_control.docker_control_client.DockerControlClient" : uses get_container()
+```
+Sources: [app/backend/docker_control/docker_control_client.py:22-149](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L22-L149), [app/backend/docker_control/views.py:127-168](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/views.py#L127-L168), [app/backend/docker_control/health_monitor.py:91-96](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L91-L96)
+
+## Key Functions Reference
+
+| Function | File | Purpose |
+| :--- | :--- | :--- |
+| `_poll_deployment_to_completion` | `docker_utils.py` | Blocks until a FastAPI deployment job reaches a terminal state [app/backend/docker_control/docker_utils.py:34-70](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py#L34-L70). |
+| `map_board_type_to_device_name` | `docker_utils.py` | Converts internal board strings (e.g., "T3K") to Inference Server device names (e.g., "t3k") [app/backend/docker_control/docker_utils.py:135-168](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py#L135-L168). |
+| `_ensure_network` | `docker_utils.py` | Ensures the `tt_studio_network` exists via the `docker-control-service` on module load [app/backend/docker_control/docker_utils.py:73-90](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py#L73-L90). |
+| `_run_direct_container` | `docker_utils.py` | Runs containers directly (bypassing Inference Server) for non-chat models like `FACE_RECOGNITION` [app/backend/docker_control/docker_utils.py:170-205](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py#L170-L205). |
+| `resolve_deploy_image` | `tt_inference_client.py` | Asks the Inference Server which image it will actually deploy for a model to enable accurate pre-pulling [app/backend/docker_control/tt_inference_client.py:45-81](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L45-L81). |
+
+Sources: [app/backend/docker_control/docker_utils.py](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_utils.py), [app/backend/docker_control/tt_inference_client.py](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py)1d:T25cc,# Model Control & Inference Pipeline

--- a/tt-studio/backend/index.md
+++ b/tt-studio/backend/index.md
@@ -1,0 +1,142 @@
+# Backend Services
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.vscode/extensions.json">.vscode/extensions.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.vscode/settings.json">.vscode/settings.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile">app/backend/Dockerfile</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt">app/backend/requirements.txt</a></li>
+</ul>
+</details>
+
+
+
+The TT-Studio Backend is a Django-based application responsible for orchestrating model lifecycles, managing hardware resources, and providing the primary API for the frontend. It operates as a central hub, coordinating between the `docker-control-service`, `inference-api`, and various model containers.
+
+The backend runs inside a Docker container, typically accessible on port `8000` [app/backend/Dockerfile:12-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L12-L12). It utilizes a `python:3.12.8-slim-bookworm` base [app/backend/Dockerfile:5-5](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L5-L5). Notably, the backend container does not mount `/var/run/docker.sock` directly; all Docker operations are proxied via HTTP with JWT authentication to ensure security [app/backend/requirements.txt:8-8](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L8-L8).
+
+## Backend Architecture & Service Map
+
+The backend is organized into several specialized Django apps, each handling a distinct domain of the TT-Studio ecosystem. It relies on `uvicorn` and `gunicorn` for serving requests [app/backend/requirements.txt:5-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L5-L11).
+
+### Backend Service Interaction
+```mermaid
+graph TD
+    subgraph "Django_Backend [Port_8000]"
+        DC["docker_control"]
+        MC["model_control"]
+        BC["board_control"]
+        LC["logs_control"]
+        VC["vector_db_control"]
+        WC["wakeword_control"]
+    end
+
+    subgraph "External_Services"
+        DCS["docker-control-service [Port_8002]"]
+        IA["inference-api [Port_8001]"]
+        CDB["ChromaDB [Port_8000/Internal]"]
+    end
+
+    subgraph "Hardware_Layer"
+        HW["Tenstorrent_Chips"]
+    end
+
+    DC <-->|"httpx/JWT"| DCS
+    MC <-->|"httpx/SSE"| IA
+    VC <-->|"langchain_chroma"| CDB
+    BC <-->|"psutil/tt-smi"| HW
+    WC <-->|"onnxruntime"| HW
+```
+Sources: [app/backend/Dockerfile:28-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L28-L45), [app/backend/requirements.txt:1-14](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L1-L14), [app/backend/requirements.txt:23-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L23-L27).
+
+### Code Entity Mapping: Core Dependencies to App Logic
+```mermaid
+graph LR
+    subgraph "Django_App_Ecosystem"
+        D["Django_5.0.4"]
+        DRF["Django_Rest_Framework"]
+        CH["Channels_4.1.0"]
+    end
+
+    subgraph "Service_Clients"
+        HX["httpx"]
+        DK["docker_python_sdk"]
+        LC["langchain"]
+    end
+
+    subgraph "Hardware_Interfaces"
+        PS["psutil"]
+        TS["tt-smi_binary"]
+        ONNX["onnxruntime"]
+    end
+
+    D --> DRF
+    DRF -.->|"API_Views"| DC["docker_control"]
+    HX -.->|"External_Requests"| DC
+    LC -.->|"RAG_Logic"| VC["vector_db_control"]
+    PS -.->|"System_Stats"| BC["board_control"]
+    TS -.->|"Chip_Telemetry"| BC
+    CH -.->|"WebSockets"| WC["wakeword_control"]
+    ONNX -.->|"Inference"| WC
+```
+Sources: [app/backend/requirements.txt:1-32](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L1-L32), [app/backend/Dockerfile:28-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L28-L45), [app/backend/Dockerfile:56-58](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L56-L58).
+
+---
+
+## Subsystems Overview
+
+### Docker Control & Container Lifecycle
+The `docker_control` app is the primary interface for managing model containers. It manages the deployment store and translates frontend requests into container lifecycle events (pull, run, stop) via the `docker-control-service`.
+
+*   **Key Logic**: Handles chip slot allocation and volume management for model weights.
+*   **Implementation**: Uses `httpx` for asynchronous communication with the control proxy [app/backend/requirements.txt:6-6](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L6-L6).
+*   **For details, see [Docker Control & Container Lifecycle](docker-control.md)**.
+
+### Model Control & Inference Pipeline
+The `model_control` app manages the high-level inference logic and the model catalog. It routes inference requests to the appropriate model container via the `inference-api` bridge.
+
+*   **Key Logic**: Orchestrates voice pipelines (Whisper to LLM) and tracks performance metrics like TTFT and TPOT.
+*   **Model Catalog**: Interprets `ModelImpl` configurations to determine hardware requirements.
+*   **For details, see [Model Control & Inference Pipeline](model-control.md)**.
+
+### Vector DB Control (RAG Backend)
+This app manages the integration with ChromaDB to provide Retrieval-Augmented Generation (RAG) capabilities. It uses `langchain` and `sentence-transformers` for processing documents [app/backend/requirements.txt:23-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L23-L28).
+
+*   **Key Logic**: Handles document ingestion (PDF, Docx), chunking, and embedding generation [app/backend/requirements.txt:9-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L9-L15).
+*   **For details, see [Vector DB Control (RAG Backend)](vector-db-control.md)**.
+
+### Board Control & Hardware Monitoring
+The `board_control` app provides real-time telemetry for the host system and Tenstorrent hardware. The backend container conditionally installs `tt-smi` (v4.1.2) via Rust to facilitate hardware detection in local mode [app/backend/Dockerfile:29-41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L29-L41).
+
+*   **Key Logic**: Uses `psutil` for CPU/RAM monitoring and `tt-smi` for Tenstorrent chip telemetry [app/backend/requirements.txt:14-14](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L14-L14).
+*   **For details, see [Board Control & Hardware Monitoring](board-control.md)**.
+
+Sources: [app/backend/Dockerfile:28-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L28-L45), [app/backend/requirements.txt:14-14](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L14-L14).
+
+### Logs Control & Bug Reporting
+This app aggregates logs from all services in the `tt_studio_network`. It provides a unified streaming API for the frontend and generates diagnostic bug reports.
+
+*   **Key Logic**: Real-time log streaming and aggregation across multi-container deployments.
+*   **For details, see [Logs Control & Bug Reporting](logs-control.md)**.
+
+---
+
+### Core Configuration & Development
+The backend environment is strictly controlled. It includes specific workarounds for dependencies like `openwakeword` (v0.6.0), which is installed without dependencies to avoid Python 3.12 wheel conflicts with `tflite-runtime`, relying instead on `onnxruntime` [app/backend/Dockerfile:56-58](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L56-L58), [app/backend/requirements.txt:13-13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L13-L13).
+
+For development, the project includes VS Code settings for consistent formatting via ESLint and Prettier [.vscode/settings.json:1-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/.vscode/settings.json#L1-L16), [.vscode/extensions.json:1-7](https://github.com/tenstorrent/tt-studio/blob/c837b829/.vscode/extensions.json#L1-L7).
+
+Sources: [app/backend/Dockerfile:5-58](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L5-L58), [app/backend/requirements.txt:1-32](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/requirements.txt#L1-L32).1c:T288d,# Docker Control & Container Lifecycle
+
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+docker-control
+model-control
+vector-db-control
+board-control
+logs-control
+```

--- a/tt-studio/backend/logs-control.md
+++ b/tt-studio/backend/logs-control.md
@@ -1,0 +1,138 @@
+# Logs Control & Bug Reporting
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py">app/backend/docker_control/deployment_sync.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py">app/backend/logs_control/views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json">app/backend/shared_config/models_from_inference_server.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/types.ts">app/frontend/src/components/bug-report/types.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/useBugReport.ts">app/frontend/src/components/bug-report/useBugReport.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py">docker-control-service/routers/logs.py</a></li>
+</ul>
+</details>
+
+
+
+The `logs_control` Django application is responsible for centralizing system diagnostics, providing log retrieval for system services, and orchestrating the generation of comprehensive bug reports. It aggregates data from the backend, the `docker-control-service`, the AI agent, and inference artifacts.
+
+## Architecture & Data Flow
+
+The `logs_control` app acts as an aggregator. While some logs (like the Django backend logs) are stored locally on a persistent volume, others must be fetched via HTTP from sibling services or read from shared Docker volumes.
+
+### Log Aggregation Topology
+
+The following diagram illustrates how `logs_control` gathers data from across the TT-Studio ecosystem to provide a unified view.
+
+**Log Collection Architecture**
+```mermaid
+graph TD
+    subgraph Frontend_Space["Frontend Space"]
+        A["BugReportModal.tsx"] -- "GET /logs-api/bug-report/" --> B["BugReportDataView"]
+        A -- "GET /logs-api/bug-report/download/" --> C["BugReportDownloadView"]
+        D["Logs_Control_UI"] -- "GET /logs-api/get-log/<path:filename>/" --> E["GetLogView"]
+    end
+
+    subgraph Django_Backend["Django Backend (logs_control)"]
+        B["BugReportDataView"]
+        C["BugReportDownloadView"]
+        E["GetLogView"]
+        F["_collect_bug_report_data()"]
+    end
+
+    subgraph External_Services["External Services"]
+        G["docker-control-service:8002"] -- "HTTP /api/v1/logs/*" --> F
+        H["inference-api:8001"] -- "Volume: .artifacts/" --> F
+        I["Agent_Container"] -- "Docker API" --> G
+    end
+
+    F -- "Aggregates" --> B
+    F -- "Zips" --> C
+```
+Sources: [app/backend/logs_control/views.py:32-47](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L32-L47), [app/backend/logs_control/views.py:228-232](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L228-L232), [app/frontend/src/components/bug-report/useBugReport.ts:209-211](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/useBugReport.ts#L209-L211), [docker-control-service/routers/logs.py:23-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L23-L45)
+
+## Bug Reporting System
+
+The bug reporting system is designed to simplify troubleshooting by bundling environment state, logs, and hardware telemetry into a single ZIP archive.
+
+### Bug Report Manifest
+The system follows a strict manifest defined in `BUG_REPORT_MANIFEST` to ensure all critical debugging information is captured.
+
+| Data Key | Destination in ZIP | Source Mechanism |
+| :--- | :--- | :--- |
+| `backend_log` | `backend.log` | Persistent volume `backend_volume/python_logs/` |
+| `model_run_log` | `model_run.log` | Proxy to `docker-control-service` `/api/v1/logs/fastapi` |
+| `model_run_deployment_logs`| `model_run_logs/<name>.log` | Volume mount `TT_STUDIO_ROOT/logs/model_run_logs/` |
+| `docker_control_log`| `docker-control-service.log` | Proxy to `docker-control-service` `/api/v1/logs/service` |
+| `agent_log` | `agent.log` | Container logs via `docker-control-service` |
+| `inference_run_logs`| `inference_artifacts/run_logs/` | Volume `.artifacts/tt-inference-server/workflow_logs/` |
+| `tt_smi` | `tt_smi.json` | `board_control.services.SystemResourceService` |
+| `deployments` | `deployments.json` | `backend_volume/deployments.json` |
+| `current_models` | `current_models.json` | Snapshot of `docker-control` and `model_control` cache |
+
+Sources: [app/backend/logs_control/views.py:32-47](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L32-L47)
+
+### Implementation Details
+1.  **Collection**: The `_collect_bug_report_data` function gathers metadata and small log snippets to show a preview in the UI [app/backend/logs_control/views.py:228-232](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L228-L232).
+2.  **ZIP Generation**: `BugReportDownloadView` performs the heavy lifting. It creates an in-memory ZIP file using `zipfile.ZipFile(io.BytesIO())` [app/backend/logs_control/views.py:461-464](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L461-L464).
+3.  **Frontend Integration**: The `useBugReport` hook manages the multi-step collection process: `form` → `collecting` → `actions` [app/frontend/src/components/bug-report/useBugReport.ts:189-201](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/useBugReport.ts#L189-L201). It generates a stable `diagnosticsRef` (e.g., `ttbr-abcd...`) to link the ZIP file to a GitHub issue [app/frontend/src/components/bug-report/useBugReport.ts:54-60](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/useBugReport.ts#L54-L60).
+
+## Log Retrieval & Monitoring
+
+TT-Studio provides access to logs for various system components through specialized views.
+
+### Code Entity Relationship: Log Access
+The following diagram maps the frontend UI components to the backend views and the underlying log sources they access.
+
+**Log Access Mapping**
+```mermaid
+graph LR
+    subgraph Frontend_Entities["Frontend Entities"]
+        URS["useBugReport.ts"]
+        TYPES["types.ts (BugReportData)"]
+    end
+
+    subgraph Backend_Entities["Backend Entities (logs_control/views.py)"]
+        FALV["FastAPILogsView"]
+        TILV["TtInferenceLogsView"]
+        BRDV["BugReportDataView"]
+        GLV["GetLogView"]
+    end
+
+    subgraph Data_Sources["Data Sources / Proxies"]
+        MRLOG["model_run.log (filesystem)"]
+        DCS["docker-control-service (port 8002)"]
+        PV["Persistent Volume (LOGS_ROOT)"]
+    end
+
+    URS -- "calls /logs-api/bug-report/" --> BRDV
+    FALV -- "reads" --> MRLOG
+    TILV -- "proxies /api/v1/containers/logs" --> DCS
+    GLV -- "reads" --> PV
+    BRDV -- "fetches /api/v1/logs/fastapi" --> DCS
+```
+Sources: [app/backend/logs_control/views.py:118-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L118-L123), [app/backend/logs_control/views.py:164-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L164-L167), [app/backend/logs_control/views.py:85-90](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L85-L90), [app/frontend/src/components/bug-report/types.ts:11-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/types.ts#L11-L25), [docker-control-service/routers/logs.py:39-44](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L39-L44)
+
+### Key Functions and Classes
+
+#### Backend: `logs_control/views.py`
+*   `ListLogsView`: Recursively builds a JSON tree of all `.log` files found in `LOGS_ROOT` [app/backend/logs_control/views.py:50-82](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L50-L82).
+*   `GetLogView`: Retrieves the raw content of a specific log file, including security checks to prevent directory traversal by validating that the path starts with `LOGS_ROOT` [app/backend/logs_control/views.py:85-115](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L85-L115).
+*   `FastAPILogsView`: Attempts to find and return the last 20 lines of `model_run.log` (formerly `fastapi.log`) from several possible relative and absolute paths [app/backend/logs_control/views.py:118-161](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L118-L161).
+*   `TtInferenceLogsView`: Specifically handles logs for inference containers by proxying requests to the `docker-control-service` [app/backend/logs_control/views.py:164-180](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L164-L180).
+*   `BugReportDownloadView`: Orchestrates the `zipfile` creation, including fetching logs from the `docker-control-service` via `urllib.request` and reading local artifacts [app/backend/logs_control/views.py:448-520](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L448-L520).
+
+#### Docker Control Service: `routers/logs.py`
+*   `get_service_log`: Serves the `docker-control-service.log` using `_read_tail` [docker-control-service/routers/logs.py:23-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L23-L28).
+*   `get_fastapi_log`: Serves the `model_run.log` from the perspective of the control service [docker-control-service/routers/logs.py:39-44](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L39-L44).
+
+#### Frontend: `bug-report/`
+*   `useBugReport`: A custom hook that encapsulates the logic for calling the bug report endpoints, managing the collection status of various log sources, and handling the ZIP download [app/frontend/src/components/bug-report/useBugReport.ts:188-233](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/useBugReport.ts#L188-L233).
+*   `buildIssueBody`: Generates a concise Markdown body for GitHub issues that includes the `diagnosticsRef` [app/frontend/src/components/bug-report/useBugReport.ts:63-94](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/bug-report/useBugReport.ts#L63-L94).
+
+## File System & Environment
+The app relies on two primary environment variables for log location:
+1.  `INTERNAL_PERSISTENT_STORAGE_VOLUME`: The base path (aliased as `LOGS_ROOT`) for persistent backend logs [app/backend/logs_control/views.py:24](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L24).
+2.  `TT_STUDIO_ROOT`: The root directory used to locate inference artifacts and internal logs [app/backend/logs_control/views.py:25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L25).
+
+Sources: [app/backend/logs_control/views.py:24-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py#L24-L25)21:T1a3a,# Docker Control Service

--- a/tt-studio/backend/model-control.md
+++ b/tt-studio/backend/model-control.md
@@ -1,0 +1,143 @@
+# Model Control & Inference Pipeline
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py">app/backend/docker_control/deployment_sync.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py">app/backend/docker_control/tt_inference_client.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py">app/backend/logs_control/views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/connection_warmer.py">app/backend/model_control/connection_warmer.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py">app/backend/model_control/model_utils.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/pipeline_views.py">app/backend/model_control/pipeline_views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/urls.py">app/backend/model_control/urls.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json">app/backend/shared_config/models_from_inference_server.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx">app/frontend/src/components/FirstStepForm.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py">inference-api/api.py</a></li>
+</ul>
+</details>
+
+
+
+The `model_control` Django app is the central orchestrator for model metadata, inference request routing, and performance tracking. It manages the lifecycle of inference requests from the frontend to deployed model containers, handles Server-Sent Events (SSE) streaming, and implements a multi-stage voice pipeline.
+
+## Model Configuration & Catalog
+
+TT-Studio uses a structured catalog to define model capabilities, hardware requirements, and container environments.
+
+### ModelImpl and Metadata
+The `ModelImpl` dataclass [app/backend/shared_config/model_config.py:44-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L67) is the primary configuration entity. It encapsulates:
+*   **Hardware Compatibility**: Defined via `device_configurations` (e.g., `GALAXY`, `N150`, `T3K`) [app/backend/shared_config/model_config.py:51](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L51).
+*   **Docker Runtime**: Includes `image_name`, `shm_size` (defaulting to 32G), and volume mounts for weights [app/backend/shared_config/model_config.py:49-73](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L49-L73).
+*   **Environment Injection**: Automatically configures `HF_HOME` and `WH_ARCH_YAML` based on the selected hardware [app/backend/shared_config/model_config.py:75-89](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L75-L89).
+*   **Service Interface**: Defines the `service_route` (e.g., `/v1/chat/completions`) and `health_route` [app/backend/shared_config/model_config.py:53-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L53-L64).
+
+### The Model Catalog
+The system loads model definitions from `models_from_inference_server.json`. This file maps high-level model names (e.g., "Llama-3.1-8B-Instruct") to specific implementation details required for deployment [app/backend/shared_config/models_from_inference_server.json:64-94](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L64-L94).
+
+| Field | Description |
+| :--- | :--- |
+| `model_type` | Category (e.g., `CHAT`, `IMAGE_GENERATION`, `SPEECH_RECOGNITION`) [app/backend/shared_config/models_from_inference_server.json:65](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L65) |
+| `inference_engine` | The underlying server (e.g., `vLLM`, `media`, `forge`) [app/backend/shared_config/models_from_inference_server.json:81](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L81) |
+| `docker_image` | The specific GHCR image reference for the model version [app/backend/shared_config/models_from_inference_server.json:84](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L84) |
+
+**Sources:** [app/backend/shared_config/model_config.py:44-89](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L89), [app/backend/shared_config/models_from_inference_server.json:1-231](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L1-L231), [app/backend/model_control/apps.py:18-22](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/apps.py#L18-L22)
+
+---
+
+## Inference Execution Flow
+
+Inference requests are handled through a multi-layered bridge that connects the React frontend to the model containers.
+
+### Deployment Initiation
+When a user selects a model in `FirstStepForm.tsx` [app/frontend/src/components/FirstStepForm.tsx:173-202](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L173-L202), the backend uses the `tt_inference_client` to start the deployment. The `start_chat_deployment` function sends a POST request to the `inference-api` (port 8001) `/run` endpoint [app/backend/docker_control/tt_inference_client.py:84-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L123). This bridge uses `TTInferenceRunResult` to communicate deployment status and `job_id` back to the UI [app/backend/docker_control/tt_inference_client.py:16-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L16-L21).
+
+### Lifecycle Synchronization
+Because deployments are asynchronous, the `deployment_sync.py` module manages the transition from a "starting" placeholder to a "running" state [app/backend/docker_control/deployment_sync.py:5-22](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L5-L22). The `_poll_and_sync` function polls the FastAPI `/run/progress/{job_id}` endpoint [app/backend/docker_control/deployment_sync.py:120-132](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L120-L132) and updates the `ModelDeployment` record with the real Docker `container_id` once the job is "completed" [app/backend/docker_control/deployment_sync.py:63-93](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L63-L93).
+
+### Request Routing & Proxying
+The `model_control` app routes inference requests based on the `internal_url` stored in the deployment cache [app/backend/model_control/model_utils.py:111-145](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L111-L145). It uses `_vllm_client` (an `httpx.AsyncClient`) with connection pooling to manage high-concurrency streaming to vLLM or Cloud providers [app/backend/model_control/model_utils.py:31-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L31-L38).
+
+To minimize cold-start latency, a `connection_warmer` background thread performs periodic `GET /health` pings every 500ms and dummy `max_tokens=1` inference requests every 30s to keep TCP sockets and vLLM pipelines active [app/backend/model_control/connection_warmer.py:5-17](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/connection_warmer.py#L5-L17).
+
+**Inference Pipeline Diagram**
+```mermaid
+graph TD
+    subgraph "Frontend_Space_(React)"
+        A["ChatComponent"] -- "POST /models-api/inference/" --> B["InferenceView_(views.py)"]
+    end
+
+    subgraph "Backend_Space_(Django)"
+        B -- "lookup" --> C["get_deploy_cache()"]
+        C -- "ModelImpl" --> D["model_utils.py"]
+        D -- "stream_openai_passthrough()" --> E["Target_Container"]
+        F["connection_warmer.py"] -- "ping_all()" --> E
+    end
+
+    subgraph "Container_Space_(vLLM/Media)"
+        E -- "SSE_Stream" --> D
+    end
+
+    D -- "InferenceMetricsTracker" --> B
+    B -- "text/event-stream" --> A
+```
+
+**Sources:** [app/backend/model_control/model_utils.py:31-145](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L31-L145), [app/backend/docker_control/tt_inference_client.py:84-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L167), [app/backend/docker_control/deployment_sync.py:47-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L47-L160), [app/backend/model_control/connection_warmer.py:5-156](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/connection_warmer.py#L5-L156)
+
+---
+
+## Inference Metrics Tracking
+
+The `InferenceMetricsTracker` class [app/backend/model_control/metrics_tracker.py:22-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L22-L38) provides high-fidelity performance monitoring following the vLLM measurement methodology.
+
+### Key Metrics Implementation
+*   **TTFT (Time to First Token)**: Calculated as the duration from request start to the arrival of the first content token [app/backend/model_control/metrics_tracker.py:101-107](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L101-L107).
+*   **ITL (Inter-Token Latency)**: A list of intervals between consecutive content chunks [app/backend/model_control/metrics_tracker.py:62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L62).
+*   **TPOT (Time Per Output Token)**: Calculated as the mean of the ITL list [app/backend/model_control/metrics_tracker.py:109-118](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L109-L118).
+*   **TPS (Tokens Per Second)**: Derived from `total_time` and `tokens_decoded` in the final stats [app/backend/model_control/metrics_tracker.py:137-147](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L137-L147).
+
+### Thinking/Reasoning Support
+The tracker explicitly handles reasoning tokens (e.g., `<think>` blocks). It tracks `thinking_start_time` and `thinking_end_time` to provide separate stats for "Thinking Duration" vs. actual generation [app/backend/model_control/metrics_tracker.py:40-54](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L40-L54). This is supported by `REASONING_MODELS` configuration which identifies models requiring a `--reasoning-parser` [app/backend/shared_config/coding_agent_config.py:25-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py#L25-L27).
+
+**Sources:** [app/backend/model_control/metrics_tracker.py:22-147](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/metrics_tracker.py#L22-L147), [app/backend/shared_config/coding_agent_config.py:25-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py#L25-L27)
+
+---
+
+## Voice & Specialized Pipelines
+
+TT-Studio supports complex multi-model pipelines, specifically for voice-to-voice interaction via `VoicePipelineView` [app/backend/model_control/pipeline_views.py:26-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/pipeline_views.py#L26-L38).
+
+### Voice Pipeline (Whisper → LLM → TTS)
+The voice pipeline orchestrates three distinct model types in a streaming sequence:
+1.  **Speech-to-Text (STT)**: Sends an `audio_file` to a Whisper container (e.g., `distil-large-v3`) [app/backend/model_control/pipeline_views.py:72-85](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/pipeline_views.py#L72-L85).
+2.  **LLM**: Processes the transcript and streams chunks back to the client while accumulating the full response [app/backend/model_control/pipeline_views.py:118-143](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/pipeline_views.py#L118-L143).
+3.  **Text-to-Speech (TTS)**: (Optional) Converts the final LLM text to audio using either OpenAI-style or Enqueue-style endpoints [app/backend/model_control/pipeline_views.py:157-172](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/pipeline_views.py#L157-L172).
+
+### Health Monitoring
+Before routing requests, `model_utils.py` performs a `health_check` [app/backend/model_control/model_utils.py:148-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L148-L167). It specifically handles HTTP 503 "not ready" or HTTP 405 "Model is not ready" responses, which indicate that a model is still warming up or loading weights into Tenstorrent SRAM/DRAM [app/backend/model_control/model_utils.py:169-179](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L169-L179).
+
+**Entity Association Diagram**
+```mermaid
+graph LR
+    subgraph "Natural_Language_Space"
+        M1["Model_Catalog"]
+        M2["Performance_Stats"]
+        M3["Voice_Pipeline"]
+        M4["Inference_Client"]
+    end
+
+    subgraph "Code_Entity_Space"
+        C1["ModelImpl_(model_config.py)"]
+        C2["InferenceMetricsTracker_(metrics_tracker.py)"]
+        C3["VoicePipelineView_(pipeline_views.py)"]
+        C4["models_from_inference_server.json"]
+        C5["start_chat_deployment_(tt_inference_client.py)"]
+    end
+
+    M1 -.-> C1
+    M1 -.-> C4
+    M2 -.-> C2
+    M3 -.-> C3
+    M4 -.-> C5
+```
+
+**Sources:** [app/backend/model_control/model_utils.py:148-179](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L148-L179), [app/backend/model_control/pipeline_views.py:26-172](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/pipeline_views.py#L26-L172), [app/backend/shared_config/model_config.py:44-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L67), [app/backend/shared_config/models_from_inference_server.json:7-220](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L7-L220), [app/backend/docker_control/tt_inference_client.py:84-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L167)1e:T1b38,# Vector DB Control (RAG Backend)

--- a/tt-studio/backend/vector-db-control.md
+++ b/tt-studio/backend/vector-db-control.md
@@ -1,0 +1,127 @@
+# Vector DB Control (RAG Backend)
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/vector_db_control/data.py">app/backend/vector_db_control/data.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+</ul>
+</details>
+
+
+
+The `vector_db_control` system provides Retrieval-Augmented Generation (RAG) capabilities to TT-Studio. It manages the lifecycle of vector collections, document ingestion (chunking and embedding), and semantic search queries. The backend utilizes **ChromaDB** as the primary vector store and exposes a REST API for the frontend to manage knowledge sources and retrieve context during chat sessions.
+
+## System Architecture & Data Flow
+
+The RAG backend bridges natural language queries with stored document embeddings. When a user sends a message with a RAG data source selected, the system performs a similarity search in ChromaDB and injects the retrieved text into the LLM prompt.
+
+### RAG Integration Flow
+The following diagram illustrates how the frontend components interact with the backend API to perform context retrieval.
+
+**Diagram: RAG Context Retrieval Flow**
+```mermaid
+sequenceDiagram
+    participant UI as "ChatComponent (React)"
+    participant RI as "runInference.ts"
+    participant GRC as "getRagContext.ts"
+    participant API as "collections-api (Django)"
+    participant CDB as "ChromaDB"
+
+    UI->>RI: [runInference()] with ragDatasource
+    RI->>GRC: [getRagContext(request, ragDatasource)]
+    alt Single Collection
+        GRC->>API: GET /collections-api/{name}/query?query_text=...
+    else All Collections
+        GRC->>API: GET /collections-api/query-all?query_text=...
+    end
+    API->>CDB: Semantic Search (Cosine Similarity)
+    CDB-->>API: Vector Results
+    API-->>GRC: { documents: string[] }
+    GRC-->>RI: ragContext
+    RI->>RI: generatePrompt(chatHistory, ragContext)
+    RI->>UI: Stream LLM response with context
+```
+**Sources:** [app/frontend/src/components/chatui/getRagContext.ts:25-69](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L25-L69), [app/frontend/src/components/chatui/getRagContext.ts:6-115](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L6-L115)
+
+## ChromaDB Integration
+
+The system deploys ChromaDB as a separate container service (`tt_studio_chroma`) within the Docker topology.
+
+| Configuration | Value / Source |
+| :--- | :--- |
+| **Image** | `chromadb/chroma:0.5.3` [app/docker-compose.yml:165](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L165) |
+| **Port** | `8111` [app/docker-compose.yml:179](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L179) |
+| **Persistence** | Data is persisted to `${HOST_PERSISTENT_STORAGE_VOLUME}/chroma` [app/docker-compose.yml:170](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L170) |
+| **Embedding Model** | `all-MiniLM-L6-v2` (downloaded on first boot) [app/docker-compose.yml:76-78](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L76-L78) |
+| **Backend Connection** | `CHROMA_DB_HOST=tt_studio_chroma` [app/docker-compose.yml:35](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L35) |
+
+The `tt_studio_backend` includes a healthcheck that waits for ChromaDB to be ready before starting, ensuring that embedding models can be downloaded and initialized [app/docker-compose.yml:25-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L25-L27).
+
+**Sources:** [app/docker-compose.yml:164-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L164-L190), [app/docker-compose.yml:25-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L25-L27), [app/docker-compose.yml:76-78](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L76-L78)
+
+## Collection Management
+
+TT-Studio organizes knowledge into "Collections". Each collection corresponds to a ChromaDB collection and is isolated by a `X-Browser-ID` header to support session-based or user-based partitioning.
+
+### Key Operations
+*   **Creation:** Users can create new collections. Names must be alphanumeric.
+*   **Querying All:** A special collection ID `special-all` allows querying across all available collections simultaneously [app/frontend/src/components/chatui/getRagContext.ts:25-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L25-L28).
+*   **Context Retrieval:** Results from `query-all` are formatted to include the source collection name: `[From {collection_name}]\n{document_text}` [app/frontend/src/components/chatui/getRagContext.ts:39-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L39-L42).
+
+### Browser Identification
+To maintain data privacy and session persistence, the frontend generates a unique UUID stored in `localStorage` as `tt_studio_browser_id`. This ID is injected into the `X-Browser-ID` header for all RAG-related requests to the backend [app/frontend/src/components/chatui/getRagContext.ts:21-32](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L21-L32).
+
+**Sources:** [app/frontend/src/components/chatui/getRagContext.ts:21-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L21-L42), [app/frontend/src/components/chatui/getRagContext.ts:65-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L65-L67)
+
+## API Endpoints (Collections API)
+
+The Django backend exposes several endpoints for managing and querying the vector database.
+
+### Querying Endpoints
+*   **`GET /collections-api/{name}/query`**: Performs a similarity search within a specific collection using the `query_text` parameter [app/frontend/src/components/chatui/getRagContext.ts:61-69](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L61-L69).
+*   **`GET /collections-api/query-all`**: Aggregates results from all available collections. The response includes the source collection name for each document [app/frontend/src/components/chatui/getRagContext.ts:28-43](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L28-L43).
+
+### Internal Knowledge & Security
+*   **RAG Admin:** Access to management interfaces can be restricted via `VITE_ENABLE_RAG_ADMIN` and protected by `RAG_ADMIN_PASSWORD` [app/docker-compose.yml:48](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L48).
+*   **Persistent Storage:** Collections are stored in the internal volume defined by `INTERNAL_PERSISTENT_STORAGE_VOLUME` [app/docker-compose.yml:39](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L39).
+
+**Sources:** [app/frontend/src/components/chatui/getRagContext.ts:25-69](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L25-L69), [app/docker-compose.yml:35-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L35-L50)
+
+## Internal Knowledge Sources
+
+The RAG backend includes pre-configured internal data sources to provide the AI agents with knowledge about the Tenstorrent ecosystem. This includes technical details about the `tt-inference-server`, available LLM models (e.g., QwQ-32B, DeepSeek-R1, Qwen2.5), and hardware compatibility [app/backend/vector_db_control/data.py:5-40](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/vector_db_control/data.py#L5-L40).
+
+**Sources:** [app/backend/vector_db_control/data.py:5-40](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/vector_db_control/data.py#L5-L40)
+
+## Frontend Components
+
+The RAG UI is integrated into the `ChatComponent` and specialized management views.
+
+**Diagram: RAG Frontend Entity Map**
+```mermaid
+classDiagram
+    class "RagManagement.tsx" {
+        +fetchCollections()
+        +uploadDocument()
+    }
+    class "getRagContext.ts" {
+        +axios.get(/query)
+        +browserId: localStorage
+    }
+    class "runInference.ts" {
+        +getRagContext()
+        +generatePrompt()
+    }
+
+    "ChatComponent.tsx" ..> "runInference.ts" : "calls on send"
+    "runInference.ts" ..> "getRagContext.ts" : "retrieves context"
+    "getRagContext.ts" ..> "collections-api" : "REST request"
+```
+
+### Context Injection Logic
+When `runInference` is triggered, it checks for a `ragDatasource`. If present, it calls `getRagContext` which returns an array of document strings.
+*   **Single Collection:** Returns raw strings or document objects from the specific collection [app/frontend/src/components/chatui/getRagContext.ts:77-88](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L77-L88).
+*   **All Collections:** Returns strings prefixed with their source collection name [app/frontend/src/components/chatui/getRagContext.ts:39-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L39-L42).
+
+**Sources:** [app/frontend/src/components/chatui/getRagContext.ts:6-115](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L6-L115), [app/frontend/src/components/chatui/getRagContext.ts:37-44](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/getRagContext.ts#L37-L44)1f:T1f7e,# Board Control & Hardware Monitoring

--- a/tt-studio/conf.py
+++ b/tt-studio/conf.py
@@ -1,0 +1,59 @@
+# TT-Studio documentation for docs.tenstorrent.com/tt-studio/.
+import os
+
+project = "TT-Studio"
+copyright = "2026, Tenstorrent"
+author = "Tenstorrent"
+html_title = "TT-Studio"
+
+extensions = [
+    "myst_parser",
+    "sphinxcontrib.mermaid",
+    "sphinx_copybutton",
+    "sphinx_togglebutton",
+]
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
+]
+myst_fence_as_directive = ["mermaid"]
+myst_heading_anchors = 3
+source_suffix = {".md": "markdown", ".rst": "restructuredtext"}
+
+# Some reproduced code samples use a language Pygments can't lex cleanly.
+suppress_warnings = ["misc.highlighting_failure"]
+
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {
+    "collapse_navigation": False,
+    "titles_only": True,
+    "navigation_depth": 2,
+}
+templates_path = ["../shared/_templates"]
+html_static_path = ["../shared/_static", "_static"]
+html_logo = "../shared/images/tt_logo.svg"
+html_favicon = "../shared/images/favicon.png"
+html_last_updated_fmt = "%b %d, %Y"
+html_baseurl = "https://docs.tenstorrent.com/tt-studio/"
+
+_BASE = "https://docs.tenstorrent.com/"
+html_context = {
+    "logo_link_url": os.environ.get("homepage") or _BASE,
+    "search_site_base_url": _BASE,
+}
+
+mermaid_version = "10.9.1"
+mermaid_light_theme = "neutral"
+mermaid_dark_theme = "neutral"
+mermaid_init_config = {
+    "startOnLoad": False,
+    "fontFamily": "Arial, Helvetica, sans-serif",
+    "flowchart": {"useMaxWidth": True, "htmlLabels": True, "curve": "basis"},
+    "sequence": {"useMaxWidth": True},
+}
+
+
+def setup(app):
+    app.add_css_file("tt_theme.css")
+    app.add_css_file("home.css")
+    app.add_css_file("mermaid-tweaks.css")

--- a/tt-studio/docker-control-service/api-and-security.md
+++ b/tt-studio/docker-control-service/api-and-security.md
@@ -1,0 +1,142 @@
+# Docker Control Service API & Security
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py">app/backend/docker_control/docker_control_client.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py">app/backend/docker_control/health_monitor.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.dev-mode.yml">app/docker-compose.dev-mode.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py">docker-control-service/api.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py">docker-control-service/config.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py">docker-control-service/routers/logs.py</a></li>
+</ul>
+</details>
+
+
+
+The `docker-control-service` is a standalone FastAPI application running on port 8002 that acts as a secure proxy for Docker operations. In TT-Studio, backend services do not mount the Docker socket directly for security reasons; instead, they communicate with this service via a REST API protected by JWT authentication. This architecture ensures that container lifecycle management, image pulling, and network configurations are governed by strict security policies.
+
+## Service Architecture and Data Flow
+
+The `docker-control-service` runs on the host machine (outside the primary container network) to maintain direct access to `/var/run/docker.sock` while exposing a controlled interface to the `tt_studio_backend` and other internal services. This migration from direct socket mounting to a proxy pattern prevents containerized applications from gaining full root-level control over the host Docker daemon.
+
+### System Entity Mapping
+The following diagram maps the high-level service concepts to the specific code entities implementing them.
+
+**Diagram: Service Entity Mapping**
+```mermaid
+graph TD
+    subgraph Host_Space["Host Space"]
+        A["docker-control-service/api.py"] -- "Uses" --> B["docker-control-service/config.py"]
+        A -- "Routes" --> C["docker-control-service/routers/"]
+        D["docker.sock"] <--> C
+    end
+
+    subgraph Container_Space["Container Space"]
+        E["docker_control/docker_control_client.py"] -- "JWT_Request" --> A
+        F["docker_control/health_monitor.py"] -- "Polling" --> E
+    end
+
+    subgraph Code_Entities["Code Entities"]
+        E_Class["DockerControlClient"] 
+        A_App["FastAPI_app"]
+        C_Cont["containers.py"]
+        C_Img["images.py"]
+        C_Net["networks.py"]
+        C_Log["logs.py"]
+    end
+
+    E -.-> E_Class
+    A -.-> A_App
+    C -.-> C_Cont
+    C -.-> C_Img
+    C -.-> C_Net
+    C -.-> C_Log
+```
+Sources: [docker-control-service/api.py:1-60](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L1-L60), [app/backend/docker_control/docker_control_client.py:22-41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L22-L41), [docker-control-service/config.py:12-56](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L12-L56)
+
+---
+
+## REST API Endpoints
+
+The service provides a comprehensive API for managing the Docker environment required for AI model deployments.
+
+### Container Management
+- `GET /api/v1/containers`: Lists containers with optional filters for status and names [app/backend/docker_control/docker_control_client.py:75-93](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L75-L93).
+- `POST /api/v1/containers/run`: Deploys a new container. This endpoint enforces resource limits and image whitelisting [app/backend/docker_control/docker_control_client.py:100-149](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L100-L149).
+- `POST /api/v1/containers/{id}/stop`: Gracefully stops a running container with a configurable timeout [app/backend/docker_control/docker_control_client.py:151-155](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L151-L155).
+- `POST /api/v1/containers/{id}/remove`: Deletes a container and its associated volumes [app/backend/docker_control/docker_control_client.py:157-161](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L157-L161).
+- `POST /api/v1/containers/{id}/dir-size`: Recursive byte count of a path inside a container, used for monitoring model weight download progress [app/backend/docker_control/docker_control_client.py:172-194](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L172-L194).
+
+### Image and Network Operations
+- `GET /api/v1/images`: Lists available local images.
+- `POST /api/v1/images/pull`: Pulls an image from a registry, subject to the `ALLOWED_IMAGES` whitelist [docker-control-service/config.py:24-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L24-L31).
+- `GET /api/v1/networks`: Lists Docker networks. Only networks in the `ALLOWED_NETWORKS` list (e.g., `tt_studio_network`) can be targeted for container attachments [docker-control-service/config.py:33-37](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L33-L37).
+
+### Log Access
+The service also provides access to host-level logs that are otherwise inaccessible to containerized services through the `logs` router [docker-control-service/routers/logs.py:9-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L9-L45):
+- `GET /api/v1/logs/service`: Tail of the Docker Control Service logs [docker-control-service/routers/logs.py:23-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L23-L28).
+- `GET /api/v1/logs/startup`: Tail of the system startup logs [docker-control-service/routers/logs.py:31-37](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L31-L37).
+- `GET /api/v1/logs/fastapi`: Tail of the FastAPI inference bridge logs [docker-control-service/routers/logs.py:39-44](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L39-L44).
+
+Sources: [app/backend/docker_control/docker_control_client.py:73-200](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L73-L200), [docker-control-service/routers/logs.py:1-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/routers/logs.py#L1-L45)
+
+---
+
+## Security Policies and Implementation
+
+Security is implemented through a combination of authentication, resource constraints, and operation whitelisting defined in the `Settings` class [docker-control-service/config.py:12-56](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L12-L56).
+
+### JWT Authentication
+Every request to the service must include a valid JWT in the `Authorization` header.
+- **Generation**: The `DockerControlClient` in the backend generates tokens using `HS256` and the `DOCKER_CONTROL_JWT_SECRET` [app/backend/docker_control/docker_control_client.py:43-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L43-L53).
+- **Validation**: The service uses `authenticate_request` middleware to verify tokens before passing the request to routers [docker-control-service/api.py:51-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L51-L52).
+
+### Hardened Configuration
+The service enforces several safety limits to prevent resource exhaustion or unauthorized access:
+
+| Policy | Value / Constraint | Code Reference |
+| :--- | :--- | :--- |
+| **Image Whitelist** | `ghcr.io/tenstorrent/`, `alpine:`, `ubuntu:`, etc. | [docker-control-service/config.py:24-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L24-L31) |
+| **Network Whitelist** | `tt_studio_network`, `bridge`, `host` | [docker-control-service/config.py:33-37](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L33-L37) |
+| **Memory Limit** | Max 16GB per container | [docker-control-service/config.py:40](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L40) |
+| **CPU Limit** | Max 8 CPUs per container | [docker-control-service/config.py:41](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L41) |
+| **CORS** | Restricted to `localhost:8000` and `tt-studio-backend-api` | [docker-control-service/api.py:39-49](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L39-L49) |
+
+### Implementation of Health Monitoring
+The `health_monitor.py` module uses the `DockerControlClient` to poll the service and synchronize the state of `ModelDeployment` records in the database with actual container states on the host [app/backend/docker_control/health_monitor.py:91-110](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L91-L110). It also handles the cleanup of stale "starting" records that might block hardware chip slots via `_cleanup_stale_starting_records` [app/backend/docker_control/health_monitor.py:19-74](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L19-L74).
+
+**Diagram: Health Monitoring Logic**
+```mermaid
+sequenceDiagram
+    participant HM as health_monitor.py
+    participant DCC as DockerControlClient
+    participant DCS as docker-control-service
+    participant DB as Django_DB_ModelDeployment
+
+    HM->>DB: filter(status="running")
+    DB-->>HM: List of deployments
+    loop For each deployment
+        HM->>DCC: get_container(container_id)
+        DCC->>DCS: GET /api/v1/containers/{id}
+        DCS-->>DCC: JSON (status: "exited")
+        DCC-->>HM: Status data
+        HM->>DB: Update status to "exited", set stopped_at
+    end
+    HM->>HM: _cleanup_stale_starting_records()
+```
+Sources: [app/backend/docker_control/health_monitor.py:76-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L76-L128), [docker-control-service/config.py:12-56](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L12-L56), [docker-control-service/api.py:39-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L39-L52)
+
+---
+
+## Configuration and Environment
+
+The service behavior is controlled via environment variables typically set in the `.env` file or passed by `run.py`.
+
+- `DOCKER_CONTROL_JWT_SECRET`: The shared secret used to sign and verify JWTs [docker-control-service/config.py:21](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L21).
+- `DEV_MODE`: If `true`, enables FastAPI auto-reload and more verbose logging [docker-control-service/config.py:18](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L18).
+- `DOCKER_CONTROL_SERVICE_URL`: Used by the backend to locate the service. In development, the backend container uses `extra_hosts` to resolve the host's IP [app/backend/docker_control/docker_control_client.py:33](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L33), [app/docker-compose.dev-mode.yml:20-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.dev-mode.yml#L20-L21).
+
+The service logs its own operations and can also serve logs from other system components by reading the paths defined in `SERVICE_LOG_FILE`, `STARTUP_LOG_FILE`, and `MODEL_RUN_LOG_FILE` [docker-control-service/config.py:48-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L48-L52).
+
+Sources: [docker-control-service/config.py:1-56](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L1-L56), [app/backend/docker_control/docker_control_client.py:25-40](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L25-L40), [app/docker-compose.dev-mode.yml:7-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.dev-mode.yml#L7-L21)23:T1c15,# Inference API (FastAPI Bridge)

--- a/tt-studio/docker-control-service/index.md
+++ b/tt-studio/docker-control-service/index.md
@@ -1,0 +1,117 @@
+# Docker Control Service
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py">app/backend/docker_control/docker_control_client.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py">app/backend/docker_control/health_monitor.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.dev-mode.yml">app/docker-compose.dev-mode.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/README.md">docker-control-service/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py">docker-control-service/api.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py">docker-control-service/config.py</a></li>
+</ul>
+</details>
+
+
+
+The **Docker Control Service** is a standalone FastAPI application that serves as a secure proxy for Docker operations within the TT-Studio ecosystem. It runs on the host machine (typically port `8002`) rather than inside a container, allowing it to interact with the Docker socket (`docker.sock`) directly without exposing that socket to the broader containerized network [docker-control-service/api.py:4-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L4-L11).
+
+This service replaces direct Docker SDK usage in the backend with a controlled REST API, enforcing security policies such as image whitelisting, resource limits, and network restrictions [docker-control-service/README.md:5-23](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/README.md?plain=1#L5-L23).
+
+## System Role & Architecture
+
+The service acts as the bridge between the **TT-Studio Backend** (Django) and the host's Docker daemon. By centralizing Docker logic here, TT-Studio avoids the security risks associated with mounting the Docker socket into the web-facing backend container. In development mode, the backend communicates with this service via `host.docker.internal` [app/docker-compose.dev-mode.yml:19-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.dev-mode.yml#L19-L21).
+
+### Service Interaction Flow
+The following diagram illustrates how the `DockerControlClient` in the backend communicates with the `DockerControlService` to manage model containers.
+
+**Title: Docker Operation Proxy Flow**
+```mermaid
+graph LR
+    subgraph ContainerizedSpace[tt_studio_backend] -- "Uses DockerControlClient" --> [API_Requests]
+    end
+
+    subgraph HostSpace_Port_8002[API_Requests] -- "JWT Authenticated" --> [api.py_app]
+        [api.py_app] -- "Routes to" --> [routers/containers.py]
+        [routers/containers.py] -- "Direct Access" --> [docker.sock]
+    end
+
+    [docker.sock] -- "Spawns" --> [Model_Containers]
+```
+**Sources:** [docker-control-service/api.py:4-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L4-L11), [app/backend/docker_control/docker_control_client.py:5-10](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L5-L10), [app/docker-compose.dev-mode.yml:19-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.dev-mode.yml#L19-L21)
+
+---
+
+## Core Responsibilities
+
+*   **Secure Proxying:** Provides a RESTful interface for container lifecycle management, including `run`, `stop`, `remove`, and `rename` operations [app/backend/docker_control/docker_control_client.py:95-161](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L95-L161).
+*   **Authentication:** Enforces JWT-based security. The `DockerControlClient` generates tokens using `HS256` [app/backend/docker_control/docker_control_client.py:43-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L43-L53), which are validated by the service's `authenticate_request` middleware [docker-control-service/api.py:51-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L51-L52).
+*   **Security Policy Enforcement:** Validates operations against `ALLOWED_IMAGES` (e.g., `ghcr.io/tenstorrent/`) and `ALLOWED_NETWORKS` (e.g., `tt_studio_network`), while enforcing limits like `MAX_MEMORY` (16g) and `MAX_CPUS` (8) [docker-control-service/config.py:23-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L23-L42).
+*   **Health & State Reconciliation:** The backend's `health_monitor.py` uses the service to detect containers that died unexpectedly and to clean up stale "starting" records that might block hardware chip slots [app/backend/docker_control/health_monitor.py:76-110](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L76-L110).
+*   **Log Aggregation:** Exposes host-level logs for the studio services and individual deployment logs through dedicated routers [docker-control-service/api.py:59](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L59), [docker-control-service/config.py:48-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L48-L52).
+
+---
+
+## Key Code Entities
+
+The interaction between the backend and the control service is primarily handled by the `DockerControlClient`.
+
+| Entity | Location | Description |
+| :--- | :--- | :--- |
+| `DockerControlClient` | [app/backend/docker_control/docker_control_client.py:22](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L22) | Python wrapper used by the Django backend to call the service via `_request`. |
+| `authenticate_request` | [docker-control-service/api.py:52](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L52) | Middleware that validates JWT tokens on every incoming request. |
+| `Settings` | [docker-control-service/config.py:12](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L12) | Defines security whitelists and resource limits for the service. |
+| `check_container_health` | [app/backend/docker_control/health_monitor.py:76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L76) | Backend task that polls the service to sync DB state with actual Docker state. |
+| `dir_size` | [app/backend/docker_control/docker_control_client.py:172](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L172) | Specialized helper to monitor folder sizes inside containers for download progress. |
+
+**Title: Code Entity Association**
+```mermaid
+classDiagram
+    class DockerControlClient {
+        +list_containers()
+        +run_container()
+        +stop_container()
+        +dir_size(container_id, path)
+    }
+    class Settings {
+        +ALLOWED_IMAGES
+        +ALLOWED_NETWORKS
+        +MAX_MEMORY
+        +JWT_SECRET
+    }
+    class HealthMonitor {
+        +check_container_health()
+        +_cleanup_stale_starting_records()
+    }
+
+    DockerControlClient ..> Settings : "Constrained by"
+    HealthMonitor --> DockerControlClient : "Uses get_container()"
+    DockerControlClient --|> "FastAPI_app" : "Calls via REST"
+```
+**Sources:** [app/backend/docker_control/docker_control_client.py:22-195](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L22-L195), [docker-control-service/config.py:12-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L12-L42), [app/backend/docker_control/health_monitor.py:76-96](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L76-L96)
+
+---
+
+## Related Services
+
+The Docker Control Service works in tandem with two primary consumers:
+
+### Docker Control Service API & Security
+This child page covers the specific REST endpoints (containers, images, networks, logs) and the security configuration that prevents arbitrary container execution. It details how the service prevents "container breakout" and restricts deployments to verified Tenstorrent images.
+For details, see [Docker Control Service API & Security](api-and-security.md).
+
+### Inference API (FastAPI Bridge)
+The Inference API (port `8001`) uses the Docker Control Service to orchestrate the actual deployment of AI models. While the Control Service handles the low-level Docker calls, the Inference API manages the high-level logic of weight downloads and model readiness, often checking directory sizes via the control service to report progress.
+For details, see [Inference API (FastAPI Bridge)](inference-api.md).
+
+---
+**Sources:** [app/backend/docker_control/docker_control_client.py:1-195](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/docker_control_client.py#L1-L195), [docker-control-service/api.py:1-90](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/api.py#L1-L90), [docker-control-service/config.py:1-56](https://github.com/tenstorrent/tt-studio/blob/c837b829/docker-control-service/config.py#L1-L56), [app/backend/docker_control/health_monitor.py:1-171](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/health_monitor.py#L1-L171)22:T21a5,# Docker Control Service API & Security
+
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+api-and-security
+inference-api
+```

--- a/tt-studio/docker-control-service/inference-api.md
+++ b/tt-studio/docker-control-service/inference-api.md
@@ -1,0 +1,116 @@
+# Inference API (FastAPI Bridge)
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py">app/backend/docker_control/tt_inference_client.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py">app/backend/model_control/model_utils.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx">app/frontend/src/components/FirstStepForm.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py">inference-api/api.py</a></li>
+</ul>
+</details>
+
+
+
+The **Inference API** is a standalone FastAPI service (running on port 8001) that acts as a bridge between the TT-Studio Backend and the `tt-inference-server` artifact. Its primary responsibility is to orchestrate the deployment of model containers, monitor weights downloading progress, and provide real-time status updates via Server-Sent Events (SSE).
+
+## 1. Service Overview and Integration
+The Inference API integrates the `tt-inference-server` repository (either as a submodule or a downloaded artifact) into the TT-Studio ecosystem. It patches internal utilities of the inference server to ensure logs and environment variables are correctly routed within the Docker topology [inference-api/api.py:27-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L27-L51).
+
+### Key Components:
+*   **FastAPI App**: Provides REST endpoints for initiating deployments and SSE endpoints for progress tracking [inference-api/api.py:246-250](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L246-L250).
+*   **ProgressHandler**: A specialized class that monitors `run_log` files to extract percentage-based progress and status transitions [inference-api/api.py:441-450](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L441-L450).
+*   **Background Orchestrator**: Uses Python threading to execute `run_main()` from the inference server without blocking the API [inference-api/api.py:734-740](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L734-L740).
+*   **Process Isolation**: Patches `subprocess.Popen` with `start_new_session=True` to ensure model containers survive FastAPI service restarts. This is critical for LLM containers which would otherwise be terminated by signal cascades [inference-api/api.py:141-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L141-L160).
+
+Sources: [inference-api/api.py:27-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L27-L51), [inference-api/api.py:141-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L141-L160), [inference-api/api.py:246-250](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L246-L250), [inference-api/api.py:441-450](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L441-L450), [inference-api/api.py:734-740](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L734-L740)
+
+## 2. Deployment Workflow (/run)
+The `/run` endpoint is the entry point for deploying a model. It accepts hardware configurations (device type, chip IDs) and model identifiers. The backend communicates with this service via the `tt_inference_client` [app/backend/docker_control/tt_inference_client.py:84-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L97).
+
+### Natural Language to Code Entity Mapping (Deployment)
+This table maps the logical deployment steps to the specific code entities responsible for execution.
+
+| Logical Step | Code Entity | File |
+| :--- | :--- | :--- |
+| **Request Initiation** | `start_chat_deployment()` | [app/backend/docker_control/tt_inference_client.py:84-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L97) |
+| **API Entry Point** | `@app.post("/run")` | [inference-api/api.py:657-658](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L657-L658) |
+| **Validation** | `get_runtime_model_spec()` | [inference-api/api.py:694-696](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L694-L696) |
+| **Execution Thread** | `threading.Thread(target=run_model_task)` | [inference-api/api.py:734-740](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L734-L740) |
+| **Core Logic** | `run_main()` (from `tt-inference-server`) | [inference-api/api.py:164-165](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L164-L165) |
+
+### Deployment Sequence
+"Deployment Logic Flow"
+```mermaid
+sequenceDiagram
+    participant B as "tt_inference_client.py"
+    participant A as "inference-api/api.py"
+    participant PH as "ProgressHandler"
+    participant IS as "run.py (run_main)"
+
+    B->>A: POST /run {model, device, device_id}
+    A->>A: Generate job_id (UUID)
+    A->>PH: Initialize ProgressHandler(job_id)
+    A->>IS: Start run_main() in threading.Thread
+    A-->>B: 202 Accepted {job_id}
+    loop During Deployment
+        IS->>PH: Write logs to run_log file
+        PH->>PH: Parse logs for Downloading/Success/Error
+    end
+```
+Sources: [app/backend/docker_control/tt_inference_client.py:84-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L167), [inference-api/api.py:657-750](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L657-L750), [inference-api/api.py:441-450](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L441-L450)
+
+## 3. Progress Orchestration and SSE
+Because model deployments involve multi-gigabyte weight downloads and container builds, the Inference API provides a streaming progress interface via the `ProgressHandler`. The frontend tracks this via `useModels` and the deployment stepper components [app/frontend/src/components/FirstStepForm.tsx:117-121](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L117-L121).
+
+### ProgressHandler Mechanism
+The `ProgressHandler` monitors the log files generated by the `run_main` task. It uses regular expressions to detect:
+1.  **Weights Download**: Captures percentage updates (e.g., `[ 45%]`) from HuggingFace or S3 download logs [inference-api/api.py:494-500](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L494-L500).
+2.  **State Transitions**: Detects when the system moves from `downloading` to `starting` to `running` [inference-api/api.py:480-490](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L480-L490).
+3.  **Errors**: Captures tracebacks and fatal errors to report back to the UI [inference-api/api.py:515-520](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L515-L520).
+
+### Progress Code Mapping
+"Log-to-UI Progress Mapping"
+```mermaid
+graph TD
+    subgraph "Inference Server Space"
+        L["run_log file (Path)"]
+        RM["run_main() execution"]
+    end
+
+    subgraph "Inference API Space"
+        PH["ProgressHandler (class)"]
+        SSE["/run/progress/{job_id} (StreamingResponse)"]
+    end
+
+    RM -- "Writes logs via _patched_setup_run_logger" --> L
+    PH -- "tail -f on log file" --> L
+    PH -- "regex match progress %" --> PH
+    SSE -- "yield f'data: {json.dumps(event)}\n\n'" --> PH
+    
+```
+Sources: [inference-api/api.py:441-550](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L441-L550), [inference-api/api.py:753-760](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L753-L760), [inference-api/api.py:113-139](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L113-L139)
+
+## 4. Artifact Integration (`tt-inference-server`)
+The service dynamically locates the `tt-inference-server` code to allow for flexible deployment environments.
+
+*   **Search Path**: It checks `TT_INFERENCE_ARTIFACT_PATH`, then `.artifacts/tt-inference-server`, and finally the local directory [inference-api/api.py:32-35](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L32-L35).
+*   **Monkey Patching**: To ensure the inference server behaves correctly inside the Studio's Docker network, the API patches:
+    *   `workflows.utils.get_repo_root_path`: Returns the artifact directory [inference-api/api.py:59-63](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L59-L63).
+    *   `workflows.log_setup.setup_run_logger`: Ensures `run_log` file handlers are correctly attached for `ProgressHandler` to read [inference-api/api.py:113-136](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L113-L136).
+    *   `workflows_utils.default_dotenv_path`: Points to the artifact's `.env` [inference-api/api.py:70-71](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L70-L71).
+
+Sources: [inference-api/api.py:32-139](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L32-L139)
+
+## 5. API Reference Summary
+
+| Endpoint | Method | Purpose |
+| :--- | :--- | :--- |
+| `/run` | POST | Starts a model deployment task via `run_model_task`. Returns a `job_id` [inference-api/api.py:657](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L657). |
+| `/run/progress/{job_id}` | GET | SSE stream of deployment progress, logs, and status via `ProgressHandler` [inference-api/api.py:753](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L753). |
+| `/run/stop/{job_id}` | POST | Terminates a running deployment task thread [inference-api/api.py:804](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L804). |
+| `/models` | GET | Returns the list of supported models from `MODEL_SPECS` [inference-api/api.py:642](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L642). |
+| `/resolve-image` | GET | Returns the specific Docker image tag for a model/device combo via `get_runtime_model_spec` [inference-api/api.py:618](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L618). |
+
+Sources: [inference-api/api.py:618-815](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L618-L815)24:T14b6,# AI Agent Service

--- a/tt-studio/frontend/app-shell.md
+++ b/tt-studio/frontend/app-shell.md
@@ -1,0 +1,147 @@
+# Application Shell: Routing, Layout & Providers
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/LICENSE">LICENSE</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx">app/frontend/src/App.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ModelsDeployedTable.tsx">app/frontend/src/components/ModelsDeployedTable.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx">app/frontend/src/components/NavBar.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ResetIcon.tsx">app/frontend/src/components/ResetIcon.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx">app/frontend/src/components/SideBar.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatExamples.tsx">app/frontend/src/components/chatui/ChatExamples.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/contexts/ModelsContext.ts">app/frontend/src/contexts/ModelsContext.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/contexts/RefreshContext.ts">app/frontend/src/contexts/RefreshContext.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/DeviceStateContext.tsx">app/frontend/src/providers/DeviceStateContext.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx">app/frontend/src/providers/ModelsContext.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/RefreshContext.tsx">app/frontend/src/providers/RefreshContext.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/index.tsx">app/frontend/src/routes/index.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/route-config.tsx">app/frontend/src/routes/route-config.tsx</a></li>
+</ul>
+</details>
+
+
+
+The application shell of TT-Studio is built using React 18, utilizing a provider-heavy architecture to manage global state across hardware monitoring, model deployments, and UI theming. It provides a consistent layout with a persistent navigation bar and footer, while handling dynamic routing based on the state of deployed AI models.
+
+## Application Entry & Providers
+
+The entry point of the frontend application is `App.tsx`, which establishes the global provider hierarchy. These providers manage cross-cutting concerns such as theming, hardware telemetry, and model registry synchronization.
+
+### Provider Hierarchy
+The application wraps the router in several layers of context to ensure data availability across all routes:
+
+1.  **`ThemeProvider`**: Manages light/dark mode state and provides theme-switching logic [app/frontend/src/App.tsx:5-5](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L5-L5), [app/frontend/src/App.tsx:25-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L25-L25).
+2.  **`QueryClientProvider`**: Integrates `@tanstack/react-query` for server-state management and caching [app/frontend/src/App.tsx:7-7](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L7-L7), [app/frontend/src/App.tsx:26-26](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L26-L26).
+3.  **`HeroSectionProvider`**: Manages the visibility and state of the home page hero section [app/frontend/src/App.tsx:9-9](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L9-L9), [app/frontend/src/App.tsx:27-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L27-L27).
+4.  **`FooterVisibilityProvider`**: Controls whether the hardware monitoring footer is rendered, persisting state in local storage [app/frontend/src/App.tsx:10-10](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L10-L10), [app/frontend/src/App.tsx:28-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L28-L28).
+5.  **`DeviceStateProvider`**: Tracks the health and telemetry of Tenstorrent hardware devices, implementing adaptive polling intervals [app/frontend/src/routes/index.tsx:7-7](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/index.tsx#L7-L7), [app/frontend/src/routes/index.tsx:22-22](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/index.tsx#L22-L22).
+6.  **`RefreshProvider`**: Provides a global trigger mechanism (`triggerRefresh`, `triggerResetAll`) to force re-fetching of data across components [app/frontend/src/providers/RefreshContext.tsx:7-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/RefreshContext.tsx#L7-L51).
+7.  **`ModelsProvider`**: The central registry for deployed model containers and their operational status [app/frontend/src/providers/ModelsContext.tsx:41-43](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L41-L43).
+
+### Data Flow: ModelsContext
+The `ModelsProvider` is critical for the application's shell as it determines which navigation items are visible. It polls the canonical deployments endpoint every 5 seconds to maintain a fresh state of active models, pausing only during hardware resets [app/frontend/src/providers/ModelsContext.tsx:107-114](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L107-L114).
+
+| Function / Property | Description |
+| :--- | :--- |
+| `refreshModels` | Fetches `fetchDeployments` and filters for managed, non-pending deployments with a valid `model_impl` [app/frontend/src/providers/ModelsContext.tsx:64-74](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L64-L74). |
+| `canonicalToModel` | Transforms backend `CanonicalDeployment` objects into the frontend `Model` interface, including port mapping [app/frontend/src/providers/ModelsContext.tsx:26-39](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L26-L39). |
+| `hasDeployedModels` | Boolean flag indicating if any managed AI models are currently running [app/frontend/src/providers/ModelsContext.tsx:45-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L45-L45). |
+| `userStoppedModel` | Persisted state in `sessionStorage` tracking if the user manually terminated a session to suppress auto-navigation [app/frontend/src/providers/ModelsContext.tsx:46-48](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L46-L48). |
+
+**Sources:** [app/frontend/src/App.tsx:5-34](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L5-L34), [app/frontend/src/providers/ModelsContext.tsx:4-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L4-L123), [app/frontend/src/providers/RefreshContext.tsx:7-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/RefreshContext.tsx#L7-L51), [app/frontend/src/routes/index.tsx:22-41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/index.tsx#L22-L41)
+
+## Routing & Layout
+
+TT-Studio uses `react-router-dom` for client-side navigation. Routes are defined centrally in `route-config.tsx` and managed by the `AppRouter`.
+
+### Route Configuration
+Routes are generated via `getRoutes()`, which allows for conditional rendering based on environment variables. For example, `isDeployedEnabled` (from `VITE_ENABLE_DEPLOYED`) determines whether the root path `/` shows the standard `HomePage` or the `DeployedHomePage` [app/frontend/src/routes/index.tsx:16-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/index.tsx#L16-L19), [app/frontend/src/routes/route-config.tsx:8-8](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/route-config.tsx#L8-L8).
+
+Key routes include:
+*   `/chat`: The `ChatUI` interface.
+*   `/models-deployed`: Management view for active containers.
+*   `/rag-management`: Interface for document ingestion.
+*   Specialized pages for `object-detection`, `voice-agent`, `image-generation`, and `coding-agents`.
+
+### Navigation Flow Diagram
+The following diagram illustrates how the `AppRouter` maps routes to the constituent shell components and providers.
+
+**TT-Studio Shell Mapping**
+```mermaid
+graph TD
+    subgraph "Natural Language Space"
+        A["User Navigates to /chat"]
+        B["User toggles Dark Mode"]
+        C["User views Hardware Status"]
+    end
+
+    subgraph "Code Entity Space"
+        A --> AppRouter["AppRouter (routes/index.tsx)"]
+        AppRouter --> RC["getRoutes (routes/route-config.tsx)"]
+        RC --> ML["MainLayout (layouts/MainLayout.tsx)"]
+        ML --> NB["NavBar (components/NavBar.tsx)"]
+        
+        B --> TP["ThemeProvider (providers/ThemeProvider)"]
+        NB --> DT["ModeToggle (components/DarkModeToggle)"]
+        
+        C --> DSP["DeviceStateProvider (providers/DeviceStateContext)"]
+        DSP --> API["/board-api/device-state/"]
+    end
+```
+
+**Sources:** [app/frontend/src/routes/index.tsx:11-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/routes/index.tsx#L11-L42), [app/frontend/src/App.tsx:6-29](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L6-L29), [app/frontend/src/components/NavBar.tsx:40-40](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L40-L40), [app/frontend/src/providers/RefreshContext.tsx:25-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/RefreshContext.tsx#L25-L30)
+
+## Shell Components: NavBar, SideBar & Reset
+
+### NavBar
+The `NavBar` is the primary interaction point. It uses `framer-motion` for animated transitions and `lucide-react` for iconography [app/frontend/src/components/NavBar.tsx:4-24](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L4-L24).
+
+*   **Dynamic Links**: Navigation items change based on whether the current view is the "Chat UI" to maximize screen real estate [app/frontend/src/components/NavBar.tsx:132-152](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L132-L152).
+*   **Model-Type Routing**: It uses `getDestinationFromModelType` to resolve internal routes (e.g., mapping an `ObjectDetection` model type to the `/object-detection` route) [app/frontend/src/components/NavBar.tsx:48-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L48-L53).
+*   **Utility Actions**: Contains the `ModeToggle`, `ResetIcon`, and `BugReportButton` [app/frontend/src/components/NavBar.tsx:40-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L40-L42).
+
+### ResetIcon & Hardware Recovery
+The `ResetIcon` component provides a critical interface for hardware recovery. It manages a two-step process:
+1.  **Stop Containers**: Calls `deleteModel` for all active deployments [app/frontend/src/components/ResetIcon.tsx:158-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ResetIcon.tsx#L158-L160).
+2.  **Board Reset**: Executes `streamResetAction` via `/docker-api/reset_board/stream/` to perform a hardware-level reset using `tt-smi` [app/frontend/src/components/ResetIcon.tsx:163-168](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ResetIcon.tsx#L163-L168).
+
+### SideBar (Help System)
+The `SideBar` serves as a context-aware help panel. It is toggled via the `NavBar` but its content is determined by the current `location.pathname` [app/frontend/src/components/SideBar.tsx:15-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx#L15-L21).
+
+| Path | Content Displayed |
+| :--- | :--- |
+| `/` | Deployment wizard instructions (Model Selection, Deploy) [app/frontend/src/components/SideBar.tsx:28-58](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx#L28-L58). |
+| `/rag-management` | Document upload and collection management help [app/frontend/src/components/SideBar.tsx:59-95](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx#L59-L95). |
+| `/chat` | Interaction and query input guides [app/frontend/src/components/SideBar.tsx:98-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx#L98-L123). |
+| `/models-deployed` | Health monitoring and container management info [app/frontend/src/components/SideBar.tsx:124-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx#L124-L150). |
+
+**Sources:** [app/frontend/src/components/NavBar.tsx:4-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L4-L190), [app/frontend/src/components/SideBar.tsx:12-153](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SideBar.tsx#L12-L153), [app/frontend/src/components/ResetIcon.tsx:106-184](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ResetIcon.tsx#L106-L184)
+
+## Component Interactions
+
+The shell components bridge the gap between UI interactions and backend API calls.
+
+**Interaction Logic Diagram**
+```mermaid
+graph LR
+    subgraph "UI Component"
+        NB["NavBar.tsx"]
+        RI["ResetIcon.tsx"]
+        SB["SideBar.tsx"]
+    end
+
+    subgraph "API / Context Layer"
+        MC["ModelsContext (refreshModels)"]
+        RC["RefreshContext (triggerRefresh)"]
+        API["modelsDeployedApis.ts"]
+    end
+
+    NB -- "Triggers" --> RI
+    RI -- "Calls" --> API
+    API -- "Updates" --> MC
+    RI -- "Triggers" --> RC
+    SB -- "Reads Location" --> NB
+```
+
+**Sources:** [app/frontend/src/components/NavBar.tsx:257-265](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx#L257-L265), [app/frontend/src/components/ResetIcon.tsx:27-33](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ResetIcon.tsx#L27-L33), [app/frontend/src/providers/ModelsContext.tsx:64-100](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ModelsContext.tsx#L64-L100), [app/frontend/src/providers/RefreshContext.tsx:13-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/RefreshContext.tsx#L13-L16)29:T266c,# Model Deployment UI

--- a/tt-studio/frontend/build-tooling.md
+++ b/tt-studio/frontend/build-tooling.md
@@ -1,0 +1,165 @@
+# Frontend Build, Tooling & UI Component Library
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/nginx.conf">app/frontend/nginx.conf</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package-lock.json">app/frontend/package-lock.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json">app/frontend/package.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ConfirmDialog.tsx">app/frontend/src/components/ConfirmDialog.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/CopyableText.tsx">app/frontend/src/components/CopyableText.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/HealthBadge.tsx">app/frontend/src/components/HealthBadge.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/StatusBadge.tsx">app/frontend/src/components/StatusBadge.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx">app/frontend/src/components/speechToText/mainContent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/alert-dialog.tsx">app/frontend/src/components/ui/alert-dialog.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/alert.tsx">app/frontend/src/components/ui/alert.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/badge.tsx">app/frontend/src/components/ui/badge.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/card.tsx">app/frontend/src/components/ui/card.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/dialog.tsx">app/frontend/src/components/ui/dialog.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/scroll-area.tsx">app/frontend/src/components/ui/scroll-area.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/tooltip.tsx">app/frontend/src/components/ui/tooltip.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/index.css">app/frontend/src/index.css</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/vite.config.ts">app/frontend/vite.config.ts</a></li>
+</ul>
+</details>
+
+
+
+This section covers the frontend infrastructure of TT-Studio, detailing the build pipeline, the architectural choices for styling and UI primitives, and the enforcement of development standards through linting and license header management.
+
+## Build Pipeline & Development Environment
+
+TT-Studio utilizes **Vite** as the primary build tool and development server, providing a fast Hot Module Replacement (HMR) experience [app/frontend/package.json:7-10](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L7-L10). The pipeline is strictly typed using **TypeScript** [app/frontend/package.json:101](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L101).
+
+### Vite Configuration & Proxy Architecture
+The `vite.config.ts` file orchestrates the frontend's connection to the backend services. Because the frontend and backend run in separate containers during development, Vite acts as a reverse proxy to bypass CORS issues and handle specific protocol requirements like Server-Sent Events (SSE).
+
+**Vite Proxy Data Flow**
+```mermaid
+graph TD
+    subgraph Vite_Dev_Server_Port_3000["Vite Dev Server (Port 3000)"]
+        Vite_Config["vite.config.ts"]
+        HMR["HMR Engine"]
+    end
+
+    subgraph Backend_API_Port_8000["tt-studio-backend-api (Port 8000)"]
+        Django["Django / Uvicorn"]
+    end
+
+    Vite_Config -- "Proxy: /docker-api" --> Django
+    Vite_Config -- "Proxy: /models-api" --> Django
+    Vite_Config -- "Proxy: /logs-api" --> Django
+    Vite_Config -- "Proxy: /collections-api" --> Django
+    Vite_Config -- "Proxy: /board-api" --> Django
+    Vite_Config -- "Proxy: /ws-api" --> Django
+    Vite_Config -- "Proxy: /reset-board" --> Django
+```
+
+**Key Proxy Features:**
+*   **SSE Support:** The proxy is configured to detect `text/event-stream` headers, ensuring `Cache-Control: no-cache` and `Connection: keep-alive` are maintained for real-time inference streaming [app/frontend/vite.config.ts:48-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/vite.config.ts#L48-L52).
+*   **Path Rewriting:** Virtual paths used by the frontend (e.g., `/models-api`) are mapped to the actual Django app routes (e.g., `/models/`) using `VITE_BACKEND_PROXY_MAPPING` [app/frontend/vite.config.ts:12-20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/vite.config.ts#L12-L20).
+*   **Static Asset Handling:** The `vite-plugin-static-copy` plugin ensures that ONNX models and WASM binaries for Silero VAD and ONNX Runtime are available at the root for browser-side inference [app/frontend/vite.config.ts:131-139](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/vite.config.ts#L131-L139).
+*   **Environment Injection:** The application version from `package.json` is injected into the frontend runtime via `import.meta.env.VITE_PACKAGE_VERSION` [app/frontend/vite.config.ts:141-146](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/vite.config.ts#L141-L146).
+
+**Sources:** [app/frontend/package.json:1-105](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L1-L105), [app/frontend/vite.config.ts:1-163](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/vite.config.ts#L1-L163)
+
+---
+
+## Styling Architecture
+
+TT-Studio uses **Tailwind CSS v4** for its styling engine [app/frontend/package.json:80](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L80). The architecture follows a "utility-first" approach combined with CSS variables for theming.
+
+### Theming & Layers
+The CSS entry point `index.css` organizes styles into Tailwind layers:
+1.  **Base Layer:** Defines global font families (Inter, Roboto Mono, Bricolage Grotesque) and resets default border colors to maintain compatibility between Tailwind v3 and v4 [app/frontend/src/index.css:1-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/index.css#L1-L27).
+2.  **Utility Layer:** Defines custom animations (e.g., `animate-line-shadow`) and complex background patterns (e.g., `bg-grid-pattern`) [app/frontend/src/index.css:29-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/index.css#L29-L50).
+3.  **Variable-Based Theming:** Light and Dark modes are controlled via CSS variables (e.g., `--background`, `--primary`) defined within the `:root` and `.dark` selectors [app/frontend/src/index.css:195-262](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/index.css#L195-L262).
+
+### Custom Utilities & Components
+The application extends Tailwind with specialized utilities for AI-specific UI elements, such as `chat-bubble` styles and scrollbar overrides for dark/light modes [app/frontend/src/index.css:55-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/index.css#L55-L128).
+
+**Sources:** [app/frontend/src/index.css:1-262](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/index.css#L1-L262), [app/frontend/package.json:80](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L80)
+
+---
+
+## UI Component Library
+
+The UI library is built on **Radix UI** primitives, which provide unstyled, accessible components that are then styled using Tailwind CSS and `class-variance-authority` (CVA).
+
+### Component Composition
+Most UI components follow a pattern of wrapping Radix primitives in a `React.forwardRef` to ensure they can be used with animation libraries like `framer-motion` or form libraries like `react-hook-form`.
+
+| Component | Base Primitive / Library | Purpose |
+| :--- | :--- | :--- |
+| `Dialog` | `@radix-ui/react-dialog` | General purpose modal overlays [app/frontend/src/components/ui/dialog.tsx:11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/dialog.tsx#L11) |
+| `AlertDialog` | `@radix-ui/react-alert-dialog` | Destructive action confirmations (e.g., deleting deployments) [app/frontend/src/components/ui/alert-dialog.tsx:9](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/alert-dialog.tsx#L9) |
+| `ScrollArea` | `@radix-ui/react-scroll-area` | Custom scrollable containers for chat and logs with themed scrollbars [app/frontend/src/components/ui/scroll-area.tsx:8](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/scroll-area.tsx#L8) |
+| `ConfirmDialog` | Custom Wrapper | A reusable abstraction over `AlertDialog` for common "Confirm/Cancel" patterns [app/frontend/src/components/ConfirmDialog.tsx:15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ConfirmDialog.tsx#L15) |
+| `Badge` | Custom CVA | Status indicators for hardware and deployment with status dots [app/frontend/src/components/ui/badge.tsx:16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/badge.tsx#L16) |
+| `HealthBadge` | Custom Component | Dynamic status badge that polls `/models-api/health/` every 3s [app/frontend/src/components/HealthBadge.tsx:56-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/HealthBadge.tsx#L56-L150) |
+
+### Implementation Pattern: Alert Dialog
+The `AlertDialog` implementation demonstrates how Radix primitives are extended with Tailwind classes. For example, `AlertDialogContent` applies centering logic and theme-aware borders [app/frontend/src/components/ui/alert-dialog.tsx:44](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/alert-dialog.tsx#L44).
+
+**UI Component Architecture**
+```mermaid
+graph LR
+    subgraph Radix_Primitive_Space["Radix Primitive Space"]
+        RP_Root["AlertDialogPrimitive.Root"]
+        RP_Portal["AlertDialogPrimitive.Portal"]
+        RP_Content["AlertDialogPrimitive.Content"]
+    end
+
+    subgraph Code_Entity_Space["Code Entity Space (tt-studio-frontend)"]
+        UI_Dialog["AlertDialog"]
+        UI_Content["AlertDialogContent"]
+        UI_Confirm["ConfirmDialog"]
+        UI_Health["HealthBadge"]
+    end
+
+    UI_Dialog -- "wraps" --> RP_Root
+    UI_Content -- "wraps" --> RP_Portal
+    UI_Content -- "wraps" --> RP_Content
+    UI_Confirm -- "uses" --> UI_Dialog
+    UI_Health -- "uses" --> Tooltip
+```
+
+**Sources:** [app/frontend/src/components/ui/alert-dialog.tsx:1-146](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/alert-dialog.tsx#L1-L146), [app/frontend/src/components/ui/scroll-area.tsx:1-59](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/scroll-area.tsx#L1-L59), [app/frontend/src/components/ConfirmDialog.tsx:1-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ConfirmDialog.tsx#L1-L52), [app/frontend/src/components/HealthBadge.tsx:1-217](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/HealthBadge.tsx#L1-L217)
+
+---
+
+## Production Serving & Nginx
+
+In production, the frontend is served as static assets by **Nginx**. The `nginx.conf` handles client-side routing and mirrors the Vite proxy configuration for API requests.
+
+**Nginx Configuration Logic:**
+*   **API Proxying:** Requests to `/models-api/`, `/docker-api/`, etc., are proxied to the `tt-studio-backend-api` container [app/frontend/nginx.conf:8-66](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/nginx.conf#L8-L66).
+*   **SSE Support:** Nginx disables buffering (`proxy_buffering off`) and increases timeouts to 1200s for long-running model deployment and inference streams [app/frontend/nginx.conf:16-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/nginx.conf#L16-L18).
+*   **SPA Routing:** The `try_files` directive ensures that deep links (e.g., `/chat/123`) are handled by `index.html`, allowing React Router to take over [app/frontend/nginx.conf:73](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/nginx.conf#L73).
+*   **Security Headers:** Standard headers like `X-Frame-Options: SAMEORIGIN` and `X-Content-Type-Options: nosniff` are applied globally [app/frontend/nginx.conf:77-79](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/nginx.conf#L77-L79).
+
+**Sources:** [app/frontend/nginx.conf:1-80](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/nginx.conf#L1-L80)
+
+---
+
+## Tooling & Standards Enforcement
+
+The project enforces strict coding standards and legal compliance through automated scripts and linting configurations.
+
+### ESLint & Prettier
+The project uses ESLint 9+ with the Flat Config system. Key plugins include:
+*   `@typescript-eslint`: For type-aware linting [app/frontend/package.json:88-89](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L88-L89).
+*   `eslint-plugin-react-hooks`: To enforce React's hook rules [app/frontend/package.json:96](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L96).
+*   `eslint-plugin-prettier`: To integrate formatting checks into the linting process [app/frontend/package.json:94](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L94).
+
+### SPDX Header Enforcement
+TT-Studio requires every source file to contain an SPDX license header. This is managed via:
+*   **`eslint-plugin-headers`**: Automates the check during the `npm run lint` phase [app/frontend/package.json:93](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L93).
+*   **Custom Scripts**:
+    *   `header:check:changed`: Uses `scripts/check-headers-changed.js` to verify headers only on modified files [app/frontend/package.json:21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L21).
+    *   `header:fix`: Runs `scripts/add-headers.js` to automatically prepend missing headers to files [app/frontend/package.json:23](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L23).
+
+### License Auditing
+The project includes a script to generate a comprehensive third-party license file, ensuring compliance with open-source dependencies [app/frontend/package.json:17](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L17).
+
+**Sources:** [app/frontend/package.json:11-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L11-L28), [app/frontend/package.json:63-104](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L63-L104)2e:T1886,# Model Integration & Dummy Echo Model

--- a/tt-studio/frontend/chat-ui.md
+++ b/tt-studio/frontend/chat-ui.md
@@ -1,0 +1,200 @@
+# Chat UI
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/CustomToaster.tsx">app/frontend/src/components/CustomToaster.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx">app/frontend/src/components/chatui/ChatComponent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatHistory.tsx">app/frontend/src/components/chatui/ChatHistory.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/FileDisplay.tsx">app/frontend/src/components/chatui/FileDisplay.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/Header.tsx">app/frontend/src/components/chatui/Header.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/HistoryPanel.tsx">app/frontend/src/components/chatui/HistoryPanel.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ImagePreview.tsx">app/frontend/src/components/chatui/ImagePreview.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/InferenceStats.tsx">app/frontend/src/components/chatui/InferenceStats.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/InputArea.tsx">app/frontend/src/components/chatui/InputArea.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx">app/frontend/src/components/chatui/MessageActions.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/StreamingMessage.tsx">app/frontend/src/components/chatui/StreamingMessage.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/fileUtils.tsx">app/frontend/src/components/chatui/fileUtils.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/processUploadedFiles.tsx">app/frontend/src/components/chatui/processUploadedFiles.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts">app/frontend/src/components/chatui/runInference.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts">app/frontend/src/components/chatui/types.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx">app/frontend/src/components/rag/RagManagement.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/index.ts">app/frontend/src/components/rag/index.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/pages/ChatUIPage.tsx">app/frontend/src/pages/ChatUIPage.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/tsconfig.json">app/frontend/tsconfig.json</a></li>
+</ul>
+</details>
+
+
+
+The Chat UI is the primary interface for interacting with deployed models in TT-Studio. It provides a multi-modal, stateful chat experience supporting streaming responses, RAG (Retrieval-Augmented Generation) context injection, file handling, and real-time hardware performance metrics.
+
+## Architecture & Data Flow
+
+The Chat interface is centered around `ChatComponent`, which orchestrates the conversation state, model selection, and inference execution.
+
+### Inference Execution Flow
+The following diagram illustrates the data flow from user input to the backend inference services, highlighting the integration of RAG and multi-modal processing.
+
+**Chat Inference Sequence**
+```mermaid
+sequenceDiagram
+    participant UI as "InputArea.tsx"
+    participant CC as "ChatComponent.tsx"
+    participant RI as "runInference.ts"
+    participant RAG as "getRagContext.ts"
+    participant API as "Backend API (/models-api/inference/)"
+
+    UI->>CC: handleInference(text, files)
+    CC->>CC: Update chatThreads (User Message)
+    CC->>RI: runInference(request, ragSource, history)
+    activate RI
+    RI->>RAG: getRagContext(request, datasource)
+    RAG-->>RI: context (documents)
+    RI->>RI: processUploadedFiles(files)
+    RI->>RI: generatePrompt(history, context, systemPrompt)
+    RI->>API: fetch(POST, stream: true)
+    activate API
+    API-->>RI: SSE Stream (tokens/thinking)
+    deactivate API
+    RI-->>CC: Update current message (Streaming)
+    deactivate RI
+    CC->>CC: Finalize Message & Stats
+```
+Sources: `[app/frontend/src/components/chatui/ChatComponent.tsx:40-135](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L40-L135)`, `[app/frontend/src/components/chatui/runInference.ts:18-36](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L18-L36)`, `[app/frontend/src/components/chatui/runInference.ts:181-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L181-L185)`, `[app/frontend/src/components/chatui/runInference.ts:53-55](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L53-L55)`
+
+---
+
+## Key Components
+
+### 1. ChatComponent
+The root container for the chat interface. It manages:
+*   **Persistent State:** Uses `usePersistentState` to store `chat_threads` (array of `ChatThread`) and `current_thread_index` in local storage `[app/frontend/src/components/chatui/ChatComponent.tsx:77-83](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L77-L83)`.
+*   **Model Management:** Fetches deployed models via `fetchDeployedModelsInfo` and allows switching via the `Header` `[app/frontend/src/components/chatui/ChatComponent.tsx:204-210](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L204-L210)`.
+*   **Inference Control:** Maintains an `inferenceController` (AbortController) to stop streaming requests `[app/frontend/src/components/chatui/ChatComponent.tsx:132-134](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L132-L134)`.
+*   **Hardware Awareness:** Detects board name via `useDeviceState` and injects `hardwareContext` into the inference prompt `[app/frontend/src/components/chatui/ChatComponent.tsx:43-49](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L43-L49)`.
+
+### 2. Header (Model & RAG Selection)
+The `Header` component provides controls for the environment of the current chat session:
+*   **ModelSelector:** A dropdown to switch between currently active model deployments `[app/frontend/src/components/chatui/Header.tsx:84-114](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/Header.tsx#L84-L114)`.
+*   **Knowledge Base (RAG):** A `Select` component (`ForwardedSelect`) to choose a specific ChromaDB collection or "Search All Collections" `[app/frontend/src/components/chatui/Header.tsx:123-167](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/Header.tsx#L123-L167)`.
+*   **Agent Toggle:** A switch to route requests to the `tt_studio_agent` service instead of direct LLM inference `[app/frontend/src/components/chatui/ChatComponent.tsx:93-96](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L93-L96)`.
+
+### 3. InputArea (Multi-modal Input)
+Handles user interactions for sending messages and files:
+*   **File Handling:** Supports images and text files. Text files are processed as RAG context during inference `[app/frontend/src/components/chatui/runInference.ts:57-66](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L57-L66)`.
+*   **PDF Detection:** Specifically detects PDF uploads via `PdfDetectionDialog` and prompts the user to use the RAG Management page, as PDFs require backend chunking/embedding `[app/frontend/src/components/chatui/InputArea.tsx:48-119](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/InputArea.tsx#L48-L119)`.
+*   **Voice Input:** Integrates `VoiceInput` for speech-to-text capabilities `[app/frontend/src/components/chatui/InputArea.tsx:18-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/InputArea.tsx#L18-L18)`.
+*   **Dynamic Sizing:** Automatically adjusts textarea height based on content `[app/frontend/src/components/chatui/InputArea.tsx:198-216](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/InputArea.tsx#L198-L216)`.
+
+### 4. ChatHistory & StreamingMessage
+Displays the conversation thread:
+*   **ChatHistory:** Manages the list of messages and responsive bubble widths `[app/frontend/src/components/chatui/ChatHistory.tsx:111-201](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatHistory.tsx#L111-L201)`.
+*   **StreamingMessage:** Handles the rendering of incoming tokens. It uses `processContent` to strip thinking tokens and extract reasoning blocks found between `<think>` tags `[app/frontend/src/components/chatui/StreamingMessage.tsx:22-49](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/StreamingMessage.tsx#L22-L49)`. It also handles live auto-scrolling for "thinking" blocks `[app/frontend/src/components/chatui/StreamingMessage.tsx:154-159](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/StreamingMessage.tsx#L154-L159)`.
+*   **MessageActions:** Provides per-message utilities including:
+    *   **Clipboard:** Copying message content `[app/frontend/src/components/chatui/MessageActions.tsx:61-71](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L61-L71)`.
+    *   **Feedback:** Thumbs up/down tracking with toast notifications `[app/frontend/src/components/chatui/MessageActions.tsx:73-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L73-L99)`.
+    *   **Thinking Toggle:** For models with reasoning capabilities, this toggles the visibility of the `Brain` icon and the associated thinking panel `[app/frontend/src/components/chatui/MessageActions.tsx:155-174](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L155-L174)`.
+
+---
+
+## Inference Implementation (`runInference.ts`)
+
+The `runInference` function is the core logic for executing requests. It transforms the UI state into a format compatible with the backend inference API.
+
+| Step | Description | Code Reference |
+| :--- | :--- | :--- |
+| **RAG Retrieval** | If a `ragDatasource` is selected, it calls `getRagContext` to fetch document chunks. | `[app/frontend/src/components/chatui/runInference.ts:44-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L44-L50)` |
+| **Prompt Assembly** | Uses `generatePrompt` to combine chat history, RAG context, and system prompts. | `[app/frontend/src/components/chatui/runInference.ts:143-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L143-L150)` |
+| **Multi-modal Prep** | Encodes images to `image_url` message structures or treats text files as local RAG context. | `[app/frontend/src/components/chatui/runInference.ts:57-106](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L57-L106)` |
+| **Route Selection** | Determines API endpoint based on `isAgentSelected` or `VITE_ENABLE_DEPLOYED` (Cloud vs Local). | `[app/frontend/src/components/chatui/runInference.ts:181-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L181-L185)` |
+| **Metric Tracking** | Uses `InferenceMetricsTracker` to calculate TTFT and tokens per second. | `[app/frontend/src/components/chatui/runInference.ts:16-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L16-L16)` |
+
+Sources: `[app/frontend/src/components/chatui/runInference.ts:1-220](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L1-L220)`
+
+---
+
+## Hardware Metrics & Stats
+
+TT-Studio emphasizes performance transparency. The `InferenceStats` component visualizes metrics returned by the backend or calculated by the client.
+
+### Data Structure (`InferenceStats`)
+The system tracks several key performance indicators (KPIs) defined in `types.ts`:
+*   **`user_ttft_s`**: Backend-measured Time to First Token (seconds).
+*   **`client_ttft_ms`**: Client-measured TTFT including network latency `[app/frontend/src/components/chatui/types.ts:128-128](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L128-L128)`.
+*   **`user_tpot`**: Time Per Output Token.
+*   **`thinking_duration_ms`**: Time spent in the reasoning phase `[app/frontend/src/components/chatui/types.ts:135-135](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L135-L135)`.
+*   **`token_timestamps`**: Array of `TokenTimestamp` used to calculate median, p95, and p99 token latencies `[app/frontend/src/components/chatui/types.ts:99-104](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L99-L104)`.
+
+Sources: `[app/frontend/src/components/chatui/types.ts:112-136](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L112-L136)`, `[app/frontend/src/components/chatui/MessageActions.tsx:178-184](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L178-L184)`
+
+---
+
+## Component Relationship Diagram
+
+This diagram maps UI components to their underlying logic, types, and the external RAG system.
+
+```mermaid
+graph TD
+    subgraph "UI Layer"
+        CC["ChatComponent (ChatComponent.tsx)"]
+        H["Header (Header.tsx)"]
+        IA["InputArea (InputArea.tsx)"]
+        CH["ChatHistory (ChatHistory.tsx)"]
+        MA["MessageActions (MessageActions.tsx)"]
+        SM["StreamingMessage (StreamingMessage.tsx)"]
+        HP["HistoryPanel (HistoryPanel.tsx)"]
+    end
+
+    subgraph "Logic & State"
+        RI["runInference.ts"]
+        GRC["getRagContext.ts"]
+        MT["InferenceMetricsTracker (metricsTracker.ts)"]
+        FU["fileUtils.ts"]
+    end
+
+    subgraph "Data Entities & External"
+        CT["ChatThread (ChatComponent.tsx)"]
+        CM["ChatMessage (types.ts)"]
+        IS["InferenceStats (types.ts)"]
+        RM["RagManagement (RagManagement.tsx)"]
+    end
+
+    CC --> H
+    CC --> IA
+    CC --> CH
+    CC --> HP
+    CH --> SM
+    CH --> MA
+    IA --> FU
+    CC --> RI
+    RI --> GRC
+    RI --> MT
+    CT --> CM
+    CM --> IS
+    MA --> IS
+    IA -.->|PDF Redirect| RM
+```
+Sources: `[app/frontend/src/components/chatui/ChatComponent.tsx:13-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/ChatComponent.tsx#L13-L31)`, `[app/frontend/src/components/chatui/types.ts:32-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L32-L42)`, `[app/frontend/src/components/chatui/runInference.ts:12-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L12-L16)`, `[app/frontend/src/components/chatui/InputArea.tsx:170-172](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/InputArea.tsx#L170-L172)`, `[app/frontend/src/components/chatui/HistoryPanel.tsx:18-26](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/HistoryPanel.tsx#L18-L26)`
+
+## RAG Integration and Browser Session
+
+RAG management uses a unique `X-Browser-ID` to track sessions across requests.
+
+```mermaid
+graph LR
+    subgraph "Frontend Session"
+        BID["getBrowserId()"]
+        FET["window.fetch Interceptor"]
+    end
+
+    subgraph "Backend RAG"
+        COL["fetchCollections()"]
+        DOC["fetchDocuments(collection)"]
+    end
+
+    BID -->|UUID v4| FET
+    FET -->|X-Browser-ID Header| COL
+    FET -->|X-Browser-ID Header| DOC
+```
+Sources: `[app/frontend/src/components/rag/RagManagement.tsx:67-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L67-L76)`, `[app/frontend/src/components/rag/RagManagement.tsx:79-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L79-L97)`, `[app/frontend/src/components/rag/RagManagement.tsx:160-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L160-L190)`2b:T24c1,# RAG Management UI

--- a/tt-studio/frontend/index.md
+++ b/tt-studio/frontend/index.md
@@ -1,0 +1,156 @@
+# Frontend Application
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/LICENSE">LICENSE</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package-lock.json">app/frontend/package-lock.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json">app/frontend/package.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx">app/frontend/src/App.tsx</a></li>
+</ul>
+</details>
+
+
+
+The TT-Studio frontend is a modern, responsive single-page application (SPA) built with **React 18**, **TypeScript**, and **Vite**. It provides the primary interface for hardware discovery, model deployment orchestration, and multi-modal AI interaction. The application is designed to handle real-time data streaming via Server-Sent Events (SSE) for both deployment progress and model inference.
+
+## Core Technology Stack
+| Category | Technology |
+| :--- | :--- |
+| **Framework** | React 18 (Functional Components, Hooks) [app/frontend/package.json:65](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L65) |
+| **Build Tool** | Vite 6 + SWC (Fast Refresh, Optimized Bundling) [app/frontend/package.json:90,102](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L90) |
+| **Styling** | Tailwind CSS 4 + Framer Motion (Animations) [app/frontend/package.json:61,80](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L61) |
+| **UI Components** | Radix UI Primitives + Lucide Icons [app/frontend/package.json:32-50,62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L32-L50) |
+| **State/Data** | TanStack Query (React Query) + React Context API [app/frontend/package.json:54](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L54) |
+| **Routing** | React Router DOM v6 [app/frontend/package.json:73](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L73) |
+
+## Application Architecture
+
+The application is structured around a centralized layout shell that manages navigation and global state providers. The frontend communicates with the Django backend through a series of proxied API routes defined in the Vite configuration.
+
+### System Entry and Routing
+The application initializes in `App.tsx`, wrapping the component tree in essential providers for theming, data fetching, and layout visibility [app/frontend/src/App.tsx:25-34](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L25-L34). Routing is managed by `AppRouter`, which dynamically generates routes based on a configuration file [app/frontend/src/App.tsx:6,29](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L6). The application also uses `QueryClient` from `@tanstack/react-query` to manage server state and caching [app/frontend/src/App.tsx:17-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L17-L19).
+
+### Component Hierarchy Diagram
+The following diagram illustrates the relationship between the main application shell and the functional UI modules.
+
+**Frontend Entity Map**
+```mermaid
+graph TD
+    subgraph "App_Shell_(MainLayout)"
+        App_tsx["App.tsx"] --> AppRouter["AppRouter"]
+        AppRouter --> MainLayout["MainLayout.tsx"]
+    end
+
+    subgraph "State_Providers"
+        ModelsProvider["ModelsContext.tsx"]
+        DeviceProvider["DeviceStateContext.tsx"]
+        RefreshProvider["RefreshContext.tsx"]
+        ThemeProvider["ThemeProvider.tsx"]
+        HeroSectionProvider["HeroSectionContext.tsx"]
+        FooterVisibilityProvider["FooterVisibilityContext.tsx"]
+    end
+
+    subgraph "Functional_Modules"
+        MainLayout --> DeploymentWizard["SelectionSteps.tsx"]
+        MainLayout --> ChatUI["ChatComponent.tsx"]
+        MainLayout --> RAG["RagManagement.tsx"]
+        MainLayout --> Specialized["ObjectDetection/STT/TTS"]
+    end
+
+    App_tsx -.-> ThemeProvider
+    App_tsx -.-> HeroSectionProvider
+    App_tsx -.-> FooterVisibilityProvider
+    AppRouter -.-> ModelsProvider
+    AppRouter -.-> DeviceProvider
+    AppRouter -.-> RefreshProvider
+```
+Sources: [app/frontend/src/App.tsx:25-34](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L25-L34), [app/frontend/package.json:73](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L73), [app/frontend/src/App.tsx:5-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L5-L11)
+
+## Key UI Sections
+
+The frontend is divided into several specialized modules, each handling a specific part of the AI lifecycle.
+
+### 1. Application Shell & Navigation
+The application uses a persistent layout framework to manage global state. It utilizes `ModelsContext` to track which AI models are currently deployed and `DeviceStateContext` to monitor hardware health and chip status.
+*   **Details:** See [Application Shell: Routing, Layout & Providers](app-shell.md).
+
+### 2. Model Deployment
+The deployment interface is a multi-step wizard (`SelectionSteps`) that guides users through hardware selection, chip configuration, and container deployment. It uses `useDeploymentProgress` to track real-time logs and status from the backend.
+*   **Details:** See [Model Deployment UI](model-deployment-ui.md).
+
+### 3. Chat & Inference
+The core interaction hub for LLMs and Vision-Language Models. It supports streaming responses via `StreamingMessage` and handles multi-modal inputs through a unified `InputArea`.
+*   **Details:** See [Chat UI](chat-ui.md).
+
+### 4. RAG Management
+A dedicated interface for managing vector databases. Users can create collections, upload documents (PDF/Text), and monitor embedding progress using session tracking via `X-Browser-ID`.
+*   **Details:** See [RAG Management UI](rag-ui.md).
+
+### 5. Specialized Interfaces
+Custom UIs for non-chat models, such as Object Detection, Stable Diffusion, and Speech-to-Text. This also includes the `VoiceAgent` pipeline and `wakeword_control` integration for hands-free interaction.
+*   **Details:** See [Specialized Model Interfaces](specialized-models.md).
+
+## Build and Proxy Configuration
+
+The application uses Vite to manage the development server and production build. A critical feature is the proxy mapping that routes frontend requests to the appropriate backend microservices.
+
+**API Proxy Mapping**
+```mermaid
+graph LR
+    subgraph "Frontend_Port_3000"
+        UI["React UI"]
+    end
+
+    subgraph "Vite_Proxy"
+        D_API["/docker-api"]
+        M_API["/models-api"]
+        C_API["/collections-api"]
+        W_API["/ws-api"]
+    end
+
+    subgraph "Backend_Port_8000"
+        Django["tt-studio-backend-api"]
+    end
+
+    UI --> D_API
+    UI --> M_API
+    UI --> C_API
+    UI --> W_API
+    
+    D_API --> Django
+    M_API --> Django
+    C_API --> Django
+    W_API --> Django
+```
+Sources: [app/frontend/package.json:7-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L7-L16), [app/frontend/package.json:102](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L102)
+
+### Build Pipeline
+*   **Development:** `npm run dev` starts the Vite server on port 3000 with Hot Module Replacement (HMR) [app/frontend/package.json:7](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L7).
+*   **Production:** `npm run build` executes TypeScript type-checking (`tsc`) followed by `vite build` for optimized assets [app/frontend/package.json:8](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L8).
+*   **Asset Management:** The build process includes copying static assets for specialized features like ONNX Runtime (`onnxruntime-web`) for web-based inference [app/frontend/package.json:64,83](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L64).
+*   **Tooling:** Includes ESLint for code quality and custom scripts for enforcing SPDX license headers (`header:check`, `header:fix`) [app/frontend/package.json:19-28](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L19-L28).
+*   **Details:** See [Frontend Build, Tooling & UI Component Library](build-tooling.md).
+
+## Directory Structure
+*   `src/api/`: Axios instances and API call definitions [app/frontend/src/App.tsx:8](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L8).
+*   `src/components/`: Reusable UI components (buttons, cards, chat elements) [app/frontend/src/App.tsx:11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L11).
+*   `src/hooks/`: Custom React hooks for global state and logic.
+*   `src/layouts/`: Page structure templates (e.g., `MainLayout`).
+*   `src/providers/`: React Context providers for global state [app/frontend/src/App.tsx:5-10](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L5-L10).
+*   `src/routes/`: Route definitions and path constants [app/frontend/src/App.tsx:6](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L6).
+
+Sources: [app/frontend/package.json:1-105](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/package.json#L1-L105), [app/frontend/src/App.tsx:1-47](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/App.tsx#L1-L47)28:T259e,# Application Shell: Routing, Layout & Providers
+
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+app-shell
+model-deployment-ui
+chat-ui
+rag-ui
+specialized-models
+build-tooling
+```

--- a/tt-studio/frontend/model-deployment-ui.md
+++ b/tt-studio/frontend/model-deployment-ui.md
@@ -1,0 +1,134 @@
+# Model Deployment UI
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts">app/frontend/src/api/modelsDeployedApis.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipConfigStep.tsx">app/frontend/src/components/ChipConfigStep.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx">app/frontend/src/components/DeployModelStep.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/MultiCardResetDialog.tsx">app/frontend/src/components/MultiCardResetDialog.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ResetStepRow.tsx">app/frontend/src/components/ResetStepRow.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SelectionSteps.tsx">app/frontend/src/components/SelectionSteps.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/StepperFooter.tsx">app/frontend/src/components/StepperFooter.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/StepperFormActions.tsx">app/frontend/src/components/StepperFormActions.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/magicui/AnimatedDeployButton.tsx">app/frontend/src/components/magicui/AnimatedDeployButton.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/DeleteModelDialog.tsx">app/frontend/src/components/models/DeleteModelDialog.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/ModelPreparingBanner.tsx">app/frontend/src/components/models/ModelPreparingBanner.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/ModelsDeployedCard.tsx">app/frontend/src/components/models/ModelsDeployedCard.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/row-cells/ManageCell.tsx">app/frontend/src/components/models/row-cells/ManageCell.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx">app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/stepper.tsx">app/frontend/src/components/ui/stepper.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/hooks/useDeploymentProgress.ts">app/frontend/src/hooks/useDeploymentProgress.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/hooks/useIsResetting.ts">app/frontend/src/hooks/useIsResetting.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/utils/deviceFit.ts">app/frontend/src/utils/deviceFit.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/utils/p300x2Placement.ts">app/frontend/src/utils/p300x2Placement.ts</a></li>
+</ul>
+</details>
+
+
+
+The Model Deployment UI provides a guided, multi-step workflow for configuring hardware resources and deploying AI models onto Tenstorrent hardware. It transitions from hardware detection and chip selection to model selection, and finally to real-time deployment monitoring and management.
+
+## Deployment Wizard Architecture
+
+The deployment process is encapsulated in the `SelectionSteps` component, which implements a stateful stepper to guide the user through the configuration lifecycle [app/frontend/src/components/SelectionSteps.tsx:52-74](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SelectionSteps.tsx#L52-L74).
+
+### Stepper Workflow Logic
+The wizard dynamically adjusts its steps based on the detected hardware (e.g., single-chip N150 vs. multi-chip T3K or P300x2 boards). The `useStepper` hook provides context for navigation and state management [app/frontend/src/components/ui/stepper.tsx:19-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/stepper.tsx#L19-L45).
+
+| Step | Component | Responsibility |
+| :--- | :--- | :--- |
+| **Step 1 (Selection)** | `FirstStepForm` | Filtering and selecting models compatible with the detected hardware. It handles compatibility warnings and auto-deployment triggers [app/frontend/src/components/SelectionSteps.tsx:13-13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SelectionSteps.tsx#L13-L13). |
+| **Step 2 (Hardware)** | `ChipConfigStep` | Selection between "1 Device" or "All Devices" modes and specific device ID allocation. This step is dynamically shown based on the `advancedActive` flag [app/frontend/src/components/ChipConfigStep.tsx:35-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipConfigStep.tsx#L35-L42). |
+| **Final Step (Deploy)** | `DeployModelStep` | Final confirmation, slot availability checks, and execution of the deployment job via the `AnimatedDeployButton` [app/frontend/src/components/DeployModelStep.tsx:18-43](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx#L18-L43). |
+
+### Hardware-Aware Step Injection
+For multi-chip boards (like P300x2), the UI conditionally manages `ChipConfigStep`. On P300x2, hardware configuration is often hidden behind a toggle unless existing deployments necessitate manual slot selection [app/frontend/src/components/SelectionSteps.tsx:39-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SelectionSteps.tsx#L39-L50). The `deviceFit.ts` utility helps determine preferred device groups and auto-placement logic [app/frontend/src/utils/deviceFit.ts:17-21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/utils/deviceFit.ts#L17-L21).
+
+### Natural Language to Code Entity Mapping: Deployment Wizard
+This diagram maps the user-facing deployment concepts to the underlying React components and API routes.
+
+```mermaid
+graph TD
+    subgraph "Natural Language Space"
+        A["'Choose Model'"]
+        B["'Select Hardware'"]
+        C["'Deploy Now'"]
+        D["'Watch Progress'"]
+    end
+
+    subgraph "Code Entity Space (Frontend)"
+        A1["FirstStepForm.tsx"]
+        B1["ChipConfigStep.tsx"]
+        C1["DeployModelStep.tsx"]
+        D1["AnimatedDeployButton.tsx"]
+    end
+
+    subgraph "Code Entity Space (Backend API)"
+        R1["GET /docker-api/get_containers/"]
+        R2["GET /docker-api/chip-status/"]
+        R3["POST /docker-api/deploy/"]
+        R4["GET /docker-api/deploy/progress/{job_id}/"]
+    end
+
+    A --> A1
+    B --> B1
+    C --> C1
+    D --> D1
+
+    A1 -- "lists compatible" --> R1
+    B1 -- "fetches slot status" --> R2
+    C1 -- "triggers job" --> R3
+    D1 -- "polls status" --> R4
+```
+Sources: [app/frontend/src/components/SelectionSteps.tsx:23-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/SelectionSteps.tsx#L23-L25), [app/frontend/src/components/ChipConfigStep.tsx:48-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ChipConfigStep.tsx#L48-L52), [app/frontend/src/components/DeployModelStep.tsx:110-151](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx#L110-L151), [app/frontend/src/components/magicui/AnimatedDeployButton.tsx:114-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/magicui/AnimatedDeployButton.tsx#L114-L160).
+
+## Real-time Deployment Tracking
+
+Deployment is an asynchronous process involving image pulling, weight downloading, and container orchestration.
+
+### 1. `AnimatedDeployButton` & `useDeploymentProgress`
+The `AnimatedDeployButton` manages the visual state of the deployment (rocket animation, success/failure icons) and utilizes the `useDeploymentProgress` hook to track the backend job [app/frontend/src/components/magicui/AnimatedDeployButton.tsx:20-46](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/magicui/AnimatedDeployButton.tsx#L20-L46).
+*   **Job Persistence:** Active job IDs are stored in `localStorage` (`tt_studio_active_deployment_job`) to allow the UI to resume tracking after a page refresh [app/frontend/src/components/magicui/AnimatedDeployButton.tsx:82-103](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/magicui/AnimatedDeployButton.tsx#L82-L103).
+*   **Polling Logic:** The `useDeploymentProgress` hook polls the backend for status updates. It transitions the UI when the status reaches terminal states like `completed` or `failed` [app/frontend/src/components/magicui/AnimatedDeployButton.tsx:49-79](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/magicui/AnimatedDeployButton.tsx#L49-L79).
+
+### 2. Deployment Logs & `WorkflowLogDialog`
+The `DeployModelStep` provides an interface to view detailed logs during the deployment process [app/frontend/src/components/DeployModelStep.tsx:82-107](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx#L82-L107).
+*   **Log Fetching:** Logs are retrieved from `/docker-api/deploy/logs/{jobId}/` and formatted with timestamps and severity levels [app/frontend/src/components/DeployModelStep.tsx:91-101](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx#L91-L101).
+*   **Workflow Tracking:** The `WorkflowLogDialog` component is used to display these logs in a dedicated modal, often scanning for specific error patterns like `exception:` to surface diagnostic info [app/frontend/src/components/DeployModelStep.tsx:136-138](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx#L136-L138).
+
+Sources: [app/frontend/src/components/magicui/AnimatedDeployButton.tsx:49-79](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/magicui/AnimatedDeployButton.tsx#L49-L79), [app/frontend/src/hooks/useDeploymentProgress.ts:12-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/hooks/useDeploymentProgress.ts#L12-L12), [app/frontend/src/components/DeployModelStep.tsx:110-172](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/DeployModelStep.tsx#L110-L172).
+
+## Models Deployed Management
+
+The `ModelsDeployedCard` serves as the central management hub for all active model containers. It aggregates data from the model catalog and the live Docker state.
+
+### Data Flow and Enrichment
+The UI performs "enrichment" by merging raw Docker container data with metadata from the deployment history and model catalog. The `fetchDeployments` function in `modelsDeployedApis.ts` acts as the canonical source of truth, reconciling deployment store data with live Docker status [app/frontend/src/api/modelsDeployedApis.ts:106-147](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L106-L147).
+
+```mermaid
+sequenceDiagram
+    participant UI as ModelsDeployedCard
+    participant API as modelsDeployedApis.ts
+    participant DOCKER as /docker-api/status/
+    participant CANON as /docker-api/deployments/
+    participant CHIP as /docker-api/chip-status/
+
+    UI->>API: fetchModels()
+    API->>DOCKER: GET container list
+    DOCKER-->>API: Raw Container data
+    UI->>API: fetchDeployments()
+    API->>CANON: GET canonical list
+    CANON-->>UI: Enriched CanonicalDeployment[]
+    UI->>CHIP: GET /docker-api/chip-status/
+    CHIP-->>UI: Slot allocation details
+```
+Sources: [app/frontend/src/components/models/ModelsDeployedCard.tsx:111-132](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/ModelsDeployedCard.tsx#L111-L132), [app/frontend/src/api/modelsDeployedApis.ts:137-147](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L137-L147), [app/frontend/src/api/modelsDeployedApis.ts:149-158](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L149-L158).
+
+### Key Management Features
+*   **Health Monitoring:** The `HealthCell` and `useHealthRefresh` hook monitor the health status of deployed containers to ensure they are ready for inference [app/frontend/src/components/models/ModelsDeployedCard.tsx:25-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/ModelsDeployedCard.tsx#L25-L25).
+*   **Multi-Chip Visualization:** On multi-chip boards, the UI displays physical chip slot occupancy (e.g., Device 0, Device 1) using the `ChipStatusDisplay` component [app/frontend/src/components/models/ModelsDeployedCard.tsx:53-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/ModelsDeployedCard.tsx#L53-L53).
+*   **Model Type Mapping:** The UI maps backend model types to frontend constants (e.g., `CHAT` to `ChatModel`) to drive conditional navigation to specialized interfaces like Object Detection or Image Generation [app/frontend/src/api/modelsDeployedApis.ts:73-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L73-L99).
+*   **Destructive Actions:** The `ManageCell` component provides controls for deleting models and viewing logs, but disables these actions during board resets to prevent system instability [app/frontend/src/components/models/row-cells/ManageCell.tsx:63-72](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/row-cells/ManageCell.tsx#L63-L72).
+
+Sources: [app/frontend/src/components/models/ModelsDeployedCard.tsx:76-92](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/ModelsDeployedCard.tsx#L76-L92), [app/frontend/src/components/models/row-cells/ManageCell.tsx:48-62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/models/row-cells/ManageCell.tsx#L48-L62), [app/frontend/src/api/modelsDeployedApis.ts:55-66](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L55-L66).2a:T2d94,# Chat UI

--- a/tt-studio/frontend/rag-ui.md
+++ b/tt-studio/frontend/rag-ui.md
@@ -1,0 +1,150 @@
+# RAG Management UI
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx">app/frontend/src/components/chatui/MessageActions.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts">app/frontend/src/components/chatui/runInference.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts">app/frontend/src/components/chatui/types.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx">app/frontend/src/components/rag/RagDataSourceForm.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx">app/frontend/src/components/rag/RagManagement.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/file-upload.tsx">app/frontend/src/components/ui/file-upload.tsx</a></li>
+</ul>
+</details>
+
+
+
+The RAG (Retrieval-Augmented Generation) Management UI provides a comprehensive interface for managing vector database collections, uploading documents, and configuring context injection for chat sessions. It allows users to create isolated knowledge bases, track document chunking, and perform administrative operations on collections.
+
+## Core Components
+
+### RagManagement Component
+The primary interface for users to interact with their RAG data sources. It handles the display of existing collections, their associated documents, and the primary actions for data ingestion [app/frontend/src/components/rag/RagManagement.tsx:125-131](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L125-L131). It maintains state for `ragDataSources`, `loading` status, and `expandedRows` to show document details [app/frontend/src/components/rag/RagManagement.tsx:130-140](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L130-L140).
+
+**Key Features:**
+*   **Collection Lifecycle:** Users can create new collections via the `RagDataSourceForm` [app/frontend/src/components/rag/RagDataSourceForm.tsx:11-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx#L11-L15) and delete them with a confirmation dialog [app/frontend/src/components/rag/RagManagement.tsx:244-250](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L244-L250).
+*   **Document Management:** Displays document metadata including chunk counts, file extensions, and upload dates [app/frontend/src/components/rag/RagManagement.tsx:107-115](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L107-L115).
+*   **Loading States:** Uses `RagManagementSkeleton` to provide visual feedback during data fetching [app/frontend/src/components/rag/RagManagement.tsx:32-32](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L32-L32).
+*   **Expanded Rows:** Users can toggle collection details to view specific `DocumentInfo` entries [app/frontend/src/components/rag/RagManagement.tsx:140-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L140-L150).
+
+### RagAdmin Component
+A restricted interface requiring authentication to manage all collections across the system, regardless of the browser session.
+
+**Key Features:**
+*   **Authentication:** Access is protected by a password-based challenge.
+*   **Global Visibility:** Lists all collections in the system, identifying them by user type (e.g., "Anonymous (Browser Session)" or "Authenticated User").
+*   **Bulk Management:** Allows administrators to refresh the global collection list or delete any collection in the system.
+
+**Sources:** [app/frontend/src/components/rag/RagManagement.tsx:125-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L125-L150), [app/frontend/src/components/rag/RagDataSourceForm.tsx:11-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx#L11-L25)
+
+---
+
+## Session Tracking & Security
+
+TT-Studio utilizes a unique `X-Browser-ID` to track and isolate RAG collections for anonymous users.
+
+### X-Browser-ID Implementation
+The system generates a persistent UUID stored in `localStorage` under the key `tt_studio_browser_id` to identify the browser session [app/frontend/src/components/rag/RagManagement.tsx:64-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L64-L76).
+
+1.  **Generation:** If no ID exists, a new UUID is created using `uuidv4()` [app/frontend/src/components/rag/RagManagement.tsx:71-72](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L71-L72).
+2.  **Interception:** The application wraps the native `window.fetch` to automatically inject the `X-Browser-ID` header into every request [app/frontend/src/components/rag/RagManagement.tsx:79-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L79-L97).
+
+### Data Flow: Session-Aware API Requests
+The following diagram illustrates how the `X-Browser-ID` bridges the frontend components to the backend API.
+
+**Session-Aware Request Architecture**
+```mermaid
+graph TD
+    subgraph "Frontend Space [React]"
+        A["RagManagement.tsx"] -- "calls" --> B["fetchCollections()"]
+        C["window.fetch override"] -- "injects header" --> B
+        D["localStorage: tt_studio_browser_id"] -- "provides ID" --> C
+    end
+
+    subgraph "Network Layer"
+        B -- "HTTP GET /collections-api/" --> E["Request with X-Browser-ID header"]
+    end
+
+    subgraph "Backend Space [Django]"
+        E -- "Auth Check" --> F["vector_db_control app"]
+        F -- "Filter by X-Browser-ID" --> G["ChromaDB Collections"]
+    end
+```
+**Sources:** [app/frontend/src/components/rag/RagManagement.tsx:64-97](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L64-L97)
+
+---
+
+## Document Ingestion
+
+The UI supports multi-modal document ingestion, primarily focusing on PDF and text-based documents.
+
+### Upload Workflow
+1.  **Trigger:** Users utilize the `GentleFileUpload` component or drag-and-drop files onto a collection row [app/frontend/src/components/rag/RagManagement.tsx:31-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L31-L31), [app/frontend/src/components/rag/RagManagement.tsx:137-138](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L137-L138).
+2.  **Validation:** The system detects file types (PDF, text, etc.) defined in `FileData` [app/frontend/src/components/chatui/types.ts:14-14](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L14-L14). The `RagDataSourceForm` validates collection names to ensure they contain no spaces and are at least 2 characters long [app/frontend/src/components/rag/RagDataSourceForm.tsx:16-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx#L16-L25).
+3.  **Transmission:** Files are uploaded using the `uploadDocument` function which interfaces with the backend RAG endpoints [app/frontend/src/components/rag/RagManagement.tsx:17-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L17-L19).
+
+### UI Interaction
+The `FileUpload` component uses `react-dropzone` to handle file selection and provides visual feedback via `framer-motion` animations [app/frontend/src/components/ui/file-upload.tsx:7-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/file-upload.tsx#L7-L19), [app/frontend/src/components/ui/file-upload.tsx:47-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/file-upload.tsx#L47-L50).
+
+**Sources:** [app/frontend/src/components/rag/RagManagement.tsx:137-140](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L137-L140), [app/frontend/src/components/ui/file-upload.tsx:30-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/file-upload.tsx#L30-L50), [app/frontend/src/components/chatui/types.ts:11-29](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L11-L29), [app/frontend/src/components/rag/RagDataSourceForm.tsx:16-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx#L16-L25)
+
+---
+
+## Context Injection (getRagContext)
+
+Before an inference request is sent to the LLM, the system retrieves relevant snippets from the selected RAG datasource.
+
+### Retrieval Logic
+The `getRagContext` function performs the following:
+*   **Single Collection:** Queries a specific collection using the user's prompt.
+*   **Special-All:** If the "All Collections" source is selected, it queries across all available collections and prefixes the context with the source collection name.
+
+### Integration with runInference
+`runInference.ts` orchestrates the retrieval before calling the model API:
+1.  It calls `getRagContext` if a `ragDatasource` is provided [app/frontend/src/components/chatui/runInference.ts:44-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L44-L50).
+2.  The returned documents are passed to `generatePrompt`, which formats them into a system-level context block for the LLM [app/frontend/src/components/chatui/runInference.ts:143-149](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L143-L149).
+3.  **File-based Context:** If a user uploads a text file directly in chat, `runInference` processes it as an ad-hoc RAG context via `processUploadedFiles`, merging it with any existing collection context [app/frontend/src/components/chatui/runInference.ts:15-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L15-L15), [app/frontend/src/components/chatui/runInference.ts:57-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L57-L76).
+
+**RAG Retrieval to Prompt Flow**
+```mermaid
+sequenceDiagram
+    participant UI as "ChatComponent.tsx"
+    participant RI as "runInference.ts"
+    participant GRC as "getRagContext.ts"
+    participant API as "Vector DB API"
+
+    UI->>RI: runInference(request, ragDatasource)
+    RI->>GRC: getRagContext(request, ragDatasource)
+    GRC->>API: GET /collections-api/{name}/query
+    API-->>GRC: { documents: [...] }
+    GRC-->>RI: ragContext
+    RI->>RI: generatePrompt(chatHistory, ragContext)
+    RI->>API: POST /models-api/inference/
+```
+**Sources:** [app/frontend/src/components/chatui/runInference.ts:42-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L42-L50), [app/frontend/src/components/chatui/runInference.ts:143-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L143-L150), [app/frontend/src/components/chatui/runInference.ts:57-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L57-L76)
+
+---
+
+## Key Data Structures
+
+### RagDataSource
+Defines the metadata and document list for a specific vector collection [app/frontend/src/components/rag/RagManagement.tsx:99-105](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L99-L105).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `id` | `string` | Unique identifier for the collection. |
+| `name` | `string` | User-defined name (validated to have no spaces) [app/frontend/src/components/rag/RagDataSourceForm.tsx:22-24](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx#L22-L24). |
+| `metadata` | `Record<string, string>` | Includes `created_at`, `embedding_func_name`, and `last_uploaded_document` [app/frontend/src/components/chatui/types.ts:65-69](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L65-L69). |
+| `documents` | `DocumentInfo[]` | List of files ingested into this collection [app/frontend/src/components/rag/RagManagement.tsx:103-103](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L103-L103). |
+
+### DocumentInfo
+Details regarding individual files within a collection [app/frontend/src/components/rag/RagManagement.tsx:107-115](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L107-L115).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `filename` | `string` | Original name of the uploaded file. |
+| `chunks_count` | `number` | Number of vector segments created from the file. |
+| `upload_date` | `string` | ISO timestamp of ingestion. |
+| `file_extension` | `string` | Extension used for icon rendering (e.g., PDF, TXT). |
+
+**Sources:** [app/frontend/src/components/rag/RagManagement.tsx:99-115](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx#L99-L115), [app/frontend/src/components/chatui/types.ts:62-70](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts#L62-L70), [app/frontend/src/components/rag/RagDataSourceForm.tsx:16-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagDataSourceForm.tsx#L16-L25)2c:T2ac3,# Specialized Model Interfaces

--- a/tt-studio/frontend/specialized-models.md
+++ b/tt-studio/frontend/specialized-models.md
@@ -1,0 +1,163 @@
+# Specialized Model Interfaces
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.gitignore">.gitignore</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts">app/frontend/src/api/modelsDeployedApis.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/Footer.tsx">app/frontend/src/components/Footer.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/Header.tsx">app/frontend/src/components/imageGen/Header.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/ImageGenParentComponent.tsx">app/frontend/src/components/imageGen/ImageGenParentComponent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/ShowcaseGallery.tsx">app/frontend/src/components/imageGen/ShowcaseGallery.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx">app/frontend/src/components/imageGen/StableDiffusionChat.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/types/chat.ts">app/frontend/src/components/imageGen/types/chat.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx">app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx">app/frontend/src/components/speechToText/mainContent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/dialog.tsx">app/frontend/src/components/ui/dialog.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/ui/focus-cards.tsx">app/frontend/src/components/ui/focus-cards.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenChat.tsx">app/frontend/src/components/videoGen/VideoGenChat.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenParentComponent.tsx">app/frontend/src/components/videoGen/VideoGenParentComponent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoInputArea.tsx">app/frontend/src/components/videoGen/VideoInputArea.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/api/videoGeneration.ts">app/frontend/src/components/videoGen/api/videoGeneration.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/hooks/useVideoChat.ts">app/frontend/src/components/videoGen/hooks/useVideoChat.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/types/chat.ts">app/frontend/src/components/videoGen/types/chat.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/pages/CodingAgentsPage.tsx">app/frontend/src/pages/CodingAgentsPage.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/pages/VideoGenPage.tsx">app/frontend/src/pages/VideoGenPage.tsx</a></li>
+</ul>
+</details>
+
+
+
+Specialized Model Interfaces provide tailored user experiences for non-chat model types, such as Object Detection, Image Generation, Video Generation, and Speech-to-Text. These components handle specific data modalities (video, audio, images) and visualize model-specific outputs like bounding boxes, generated media, or transcriptions.
+
+## Object Detection Interface
+
+The `ObjectDetectionComponent` is a comprehensive UI for models that identify and locate objects in images or video streams. It supports both static file uploads and live webcam feeds.
+
+### Implementation Details
+The component uses a dual-tab system (`webcam` vs `file`) to manage different input sources [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:67-68](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L67-L68). It tracks detections and metadata (such as FPS and inference time) separately for each mode [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:72-91](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L72-L91).
+
+**Key Features:**
+- **Bounding Box Scaling:** Detections are normalized and then scaled to fit the display container using `updateBoxPositions` [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:17-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L17-L18).
+- **Live Mode:** In webcam mode, it supports a "Live Mode" toggle which continuously polls the inference server for new frames [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:94-98](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L94-L98).
+- **Performance Metrics:** Displays real-time stats including Inference Time (ms), FPS, and total object counts [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:25-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L25-L31).
+
+### Data Flow: Object Detection
+The following diagram illustrates how video frames or files are processed and rendered as bounding boxes.
+
+**Object Detection Data Flow**
+```mermaid
+graph TD
+    subgraph "Frontend (ObjectDetectionComponent)"
+        A["SourcePicker / WebcamPicker"] -->|"File/Stream"| B["Inference Request"]
+        B -->|"Response (JSON)"| C["Detection Metadata"]
+        C -->|"Raw Boxes"| D["updateBoxPositions()"]
+        D -->|"Scaled Boxes"| E["Canvas/SVG Overlay"]
+    end
+    
+    subgraph "Backend (Inference Server)"
+        B --- F["Model Execution"]
+        F --- G["Bounding Box Extraction"]
+    end
+    
+    E -->|"Render"| H["User Interface"]
+```
+
+Sources: [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:182-228](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L182-L228), [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:17-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L17-L18), [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:64-98](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L64-L98)
+
+## Image Generation Interface
+
+The `ImageGenParentComponent` manages the lifecycle of image generation tasks, primarily using Stable Diffusion models. It transitions between a "Showcase" mode and an "Active Generation" mode [app/frontend/src/components/imageGen/ImageGenParentComponent.tsx:11-13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/ImageGenParentComponent.tsx#L11-L13).
+
+### Showcase and Generation
+- **ShowcaseGallery:** Displays pre-defined prompts and example images to guide users. Clicking an image populates the prompt for the active session [app/frontend/src/components/imageGen/ImageGenParentComponent.tsx:33-36](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/ImageGenParentComponent.tsx#L33-L36).
+- **StableDiffusionChat:** A chat-like interface where users send text prompts and receive generated images [app/frontend/src/components/imageGen/StableDiffusionChat.tsx:15-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx#L15-L19). It includes a `Download` action for generated artifacts [app/frontend/src/components/imageGen/StableDiffusionChat.tsx:103-111](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx#L103-L111).
+
+### Components
+| Component | Role |
+| :--- | :--- |
+| `StableDiffusionChat` | Main interaction loop using `useChat` hook [app/frontend/src/components/imageGen/StableDiffusionChat.tsx:13-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx#L13-L15). |
+| `Header` | Provides navigation and history panel toggles [app/frontend/src/components/imageGen/Header.tsx:28-33](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/Header.tsx#L28-L33). |
+| `ImageInputArea` | Text area for prompt entry and generation trigger [app/frontend/src/components/imageGen/StableDiffusionChat.tsx:161-165](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx#L161-L165). |
+
+Sources: [app/frontend/src/components/imageGen/StableDiffusionChat.tsx:95-113](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/StableDiffusionChat.tsx#L95-L113), [app/frontend/src/components/imageGen/types/chat.ts:10-15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/types/chat.ts#L10-L15), [app/frontend/src/components/imageGen/ImageGenParentComponent.tsx:45-60](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/imageGen/ImageGenParentComponent.tsx#L45-L60)
+
+## Video Generation Interface
+
+The `VideoGenChat` component provides a specialized interface for Text-to-Video (T2V) models like Wan2.2. Due to the high latency of video generation (1–5 minutes), the interface includes comprehensive progress tracking [app/frontend/src/components/videoGen/VideoGenParentComponent.tsx:53-55](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenParentComponent.tsx#L53-L55).
+
+### Implementation Details
+- **Progress Tracking:** Displays a progress bar with phases like `queued`, `in_progress`, and `finishing up`, along with elapsed vs estimated time [app/frontend/src/components/videoGen/VideoGenChat.tsx:150-170](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenChat.tsx#L150-L170).
+- **Video Player:** Renders the generated video using a standard `<video>` tag with download capabilities [app/frontend/src/components/videoGen/VideoGenChat.tsx:112-129](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenChat.tsx#L112-L129).
+- **Parent Wrapper:** `VideoGenParentComponent` handles model ID extraction from navigation state and manages the transition from the landing view to the chat view [app/frontend/src/components/videoGen/VideoGenParentComponent.tsx:12-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenParentComponent.tsx#L12-L42).
+
+Sources: [app/frontend/src/components/videoGen/VideoGenChat.tsx:21-39](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenChat.tsx#L21-L39), [app/frontend/src/components/videoGen/VideoGenParentComponent.tsx:49-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/videoGen/VideoGenParentComponent.tsx#L49-L64)
+
+## Speech-to-Text (STT) Interface
+
+The STT interface provides a robust environment for recording audio and viewing transcriptions. It is primarily implemented in `MainContent` and `AudioRecorderWithVisualizer`.
+
+### Audio Pipeline
+1.  **Recording:** Uses the `MediaRecorder` API to capture audio chunks.
+2.  **Visualization:** An `AnalyserNode` maps frequency data to UI bars to provide visual feedback during recording.
+3.  **Transcription:** The recorded `Blob` is sent to the inference backend via `sendAudioRecording` [app/frontend/src/components/speechToText/mainContent.tsx:136-140](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx#L136-L140).
+
+### Transcription Management
+Transcriptions are grouped by date and associated with specific "Conversations" [app/frontend/src/components/speechToText/mainContent.tsx:29-41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx#L29-L41). Users can edit transcribed text, copy it to the clipboard, or replay the original audio [app/frontend/src/components/speechToText/mainContent.tsx:167-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx#L167-L185).
+
+Sources: [app/frontend/src/components/speechToText/mainContent.tsx:112-164](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx#L112-L164), [app/frontend/src/components/speechToText/mainContent.tsx:223-225](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx#L223-L225)
+
+## Voice Agent & Wake Word Pipeline
+
+The Voice Agent is a multi-model pipeline UI that orchestrates three distinct models: **Whisper** (STT), **LLM** (Chat), and **SpeechT5/TTS** (Text-to-Speech).
+
+### Deployment Logic
+Model types are normalized from backend strings to frontend constants to ensure correct interface routing [app/frontend/src/api/modelsDeployedApis.ts:73-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L73-L99). The `ModelType` object defines the supported categories, including `SpeechRecognitionModel`, `FaceRecognitionModel`, and `TTS` [app/frontend/src/api/modelsDeployedApis.ts:55-66](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L55-L66).
+
+**Voice Agent Component Entity Mapping**
+```mermaid
+graph LR
+    subgraph "Frontend UI Entities"
+        VAA["VoiceAgentApp.tsx"]
+        ARV["AudioRecorderWithVisualizer.tsx"]
+        MP["MetricsPanel.tsx"]
+    end
+
+    subgraph "Logic & API Space"
+        SAR["sendAudioRecording()"]
+        RI["runInference()"]
+        RTI["runTTSInference()"]
+    end
+
+    subgraph "Hardware/Model Space"
+        WH["Whisper (STT)"]
+        LL["LLM (Llama/Mistral)"]
+        TT["SpeechT5 (TTS)"]
+    end
+
+    VAA --> ARV
+    VAA --> MP
+    ARV --> SAR
+    SAR --> WH
+    VAA --> RI
+    RI --> LL
+    VAA --> RTI
+    RTI --> TT
+```
+
+Sources: [app/frontend/src/api/modelsDeployedApis.ts:55-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L55-L99), [app/frontend/src/components/speechToText/mainContent.tsx:136-140](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/speechToText/mainContent.tsx#L136-L140)
+
+### Wake Word Control
+The application integrates wake-word detection using the `wakeword_control` Django app.
+- **Technology:** Utilizes `openWakeWord` ONNX models.
+- **Bundled Model:** Includes the `hey_quiet_box` model for local, offline detection.
+- **Data Flow:** The frontend establishes a WebSocket connection to the backend; when the wake word is detected, the backend sends a trigger to start the STT recording process.
+
+## Coding Agents Page
+
+The `CodingAgentsPage` provides a specialized interface for LLMs that are eligible for autonomous coding tasks.
+
+- **Eligibility:** The backend identifies `coding_agent_eligible` models in the `CanonicalDeployment` payload [app/frontend/src/api/modelsDeployedApis.ts:118](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L118).
+- **Integration:** These models are exposed via a dedicated gateway that allows the agent to execute code in a sandboxed environment (e.g., E2B) and interact with the local filesystem.
+
+Sources: [app/frontend/src/api/modelsDeployedApis.ts:106-134](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L106-L134), [app/frontend/src/pages/CodingAgentsPage.tsx:1-20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/pages/CodingAgentsPage.tsx#L1-L20)2d:T2920,# Frontend Build, Tooling & UI Component Library

--- a/tt-studio/glossary.md
+++ b/tt-studio/glossary.md
@@ -1,0 +1,143 @@
+# Glossary
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md">README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md">app/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py">app/backend/docker_control/tt_inference_client.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py">app/backend/model_control/model_utils.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html">app/frontend/index.html</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts">app/frontend/src/api/modelsDeployedApis.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx">app/frontend/src/components/FirstStepForm.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/NavBar.tsx">app/frontend/src/components/NavBar.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx">app/frontend/src/components/chatui/MessageActions.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts">app/frontend/src/components/chatui/runInference.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/types.ts">app/frontend/src/components/chatui/types.ts</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx">app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/rag/RagManagement.tsx">app/frontend/src/components/rag/RagManagement.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py">inference-api/api.py</a></li>
+</ul>
+</details>
+
+
+
+This page provides definitions for codebase-specific terms, abbreviations, and domain concepts used throughout the TT-Studio project. It serves as a technical reference for onboarding engineers to understand how high-level concepts map to specific implementation details.
+
+## Core System Concepts
+
+### Tenstorrent Hardware & Drivers
+TT-Studio is designed to orchestrate AI models on Tenstorrent AI accelerators.
+*   **TT-Metal**: The low-level programming model and hardware abstraction layer used to execute kernels on Tenstorrent chips [README.md:9](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L9).
+*   **Device Configuration**: A specification within a model's metadata defining which hardware (e.g., Grayskull, Wormhole) and how many chips are required.
+*   **Chip Slot Allocation**: The logic responsible for tracking which physical Tenstorrent chips are currently occupied by running Docker containers. Implementation is handled in the `ChipSlotAllocator` class within the `docker_control` app. It manages mapping board types like `T3K` or `GALAXY` to available slots.
+*   **Hardware Context**: Contextual information about the underlying Tenstorrent hardware (e.g., board type) passed during inference to optimize prompt generation [app/frontend/src/components/chatui/runInference.ts:28-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L28-L30).
+
+### Docker Topology
+TT-Studio uses a multi-container architecture managed via Docker Compose [app/docker-compose.yml:5-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L5-L190).
+*   **Docker Control Service**: A standalone FastAPI service (port 8002) that acts as a secure proxy for Docker socket operations, preventing the need to mount `/var/run/docker.sock` directly into the web backend [app/README.md:18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L18).
+*   **tt_studio_network**: A dedicated Docker bridge network that allows the backend to communicate with dynamically deployed model containers [app/docker-compose.yml:19-20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L19-L20), [app/docker-compose.yml:188-189](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L188-L189).
+*   **Compose Overlays**: Modular configuration files (e.g., `docker-compose.tt-hardware.yml`) that add hardware-specific capabilities like mounting `/dev/tenstorrent` [app/README.md:20-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L20-L30).
+
+---
+
+## Technical Glossary
+
+| Term | Definition | Code Pointers |
+| :--- | :--- | :--- |
+| **ModelImpl** | Specification for an AI model, including its image and hardware requirements. | [app/backend/docker_control/tt_inference_client.py:45-59](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L45-L59) |
+| **Inference API** | A FastAPI bridge (port 8001) that translates TT-Studio requests into `tt-inference-server` commands. | [inference-api/api.py:4-165](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L4-L165) |
+| **Deployment Store** | A JSON-backed persistence layer that tracks the lifecycle of deployed model containers. | [app/frontend/src/api/modelsDeployedApis.ts:103-105](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L103-L105) |
+| **TTFT** | Time To First Token. Metric measuring latency from request to first character. | [app/backend/model_control/model_utils.py:21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L21) |
+| **TPOT** | Time Per Output Token. The average time taken to generate each token after the first. | [app/backend/model_control/model_utils.py:21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L21) |
+| **RAG** | Retrieval-Augmented Generation. Queries ChromaDB to provide context to the LLM. | [app/docker-compose.yml:164-187](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L164-L187) |
+| **Canonical Deployment** | The single source of truth (SoT) object representing a live or pending container. | [app/frontend/src/api/modelsDeployedApis.ts:106-134](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L106-L134) |
+| **Deploy Cache** | A Django-based cache (using pickle) that stores enriched container metadata, including `max_model_len`. | [app/backend/model_control/model_utils.py:111-145](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L111-L145) |
+| **Tool Call Parser** | Model-specific parser used by vLLM to enable auto-tool choice for coding agents. | [app/backend/docker_control/tt_inference_client.py:24-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L24-L42) |
+
+**Sources:** [app/backend/model_control/model_utils.py:127-145](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L127-L145), [app/frontend/src/api/modelsDeployedApis.ts:106-134](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L106-L134), [app/backend/docker_control/tt_inference_client.py:24-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L24-L42)
+
+---
+
+## Data Flow & System Interactions
+
+### Inference Request Flow
+The following diagram illustrates how a user prompt moves from the React frontend through the Django backend to the specific model container, including the optional RAG context path.
+
+**Natural Language to Code Entity Space: Inference Path**
+```mermaid
+graph TD
+    subgraph "Frontend (React)"
+        A["ChatComponent.tsx"] -- "calls" --> B["runInference.ts"]
+        B -- "getRagContext()" --> RAG["getRagContext.ts"]
+        B -- "POST /models-api/inference/" --> C["Django: model_control"]
+    end
+
+    subgraph "Backend (Django)"
+        C -- "lookups" --> D["get_deploy_cache()"]
+        D -- "uses" --> E["django_deploy_cache"]
+        C -- "proxy via httpx.AsyncClient" --> F["Model Container (Port 7000+)"]
+    end
+
+    subgraph "Model Container"
+        F -- "vLLM /v1/chat/completions" --> G["SSE Stream"]
+    end
+
+    G -- "stream response" --> C
+    C -- "stream back" --> B
+    B -- "update UI" --> A
+```
+**Sources:** [app/backend/model_control/model_utils.py:31-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L31-L38), [app/backend/model_control/model_utils.py:111-125](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L111-L125), [app/frontend/src/components/chatui/runInference.ts:18-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L18-L185)
+
+### Model Deployment Lifecycle
+When a user selects a model to deploy, the system orchestrates multiple services to prepare the environment and download weights via the `inference-api` bridge.
+
+**Natural Language to Code Entity Space: Deployment Orchestration**
+```mermaid
+graph LR
+    subgraph "Frontend UI"
+        F1["FirstStepForm.tsx"] -- "Select Model" --> S1["useStepper"]
+        S1 -- "POST /docker-api/deploy/" --> B1["Django: docker_control"]
+    end
+
+    subgraph "Backend Orchestration"
+        B1 -- "start_chat_deployment()" --> T1["tt_inference_client.py"]
+        T1 -- "POST /run" --> I1["inference-api/api.py"]
+    end
+
+    subgraph "Inference Infrastructure"
+        I1 -- "calls" --> R1["run_main() (tt-inference-server)"]
+        R1 -- "isolated_popen" --> D1["Docker Engine"]
+    end
+```
+**Sources:** [app/backend/docker_control/tt_inference_client.py:84-166](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/tt_inference_client.py#L84-L166), [inference-api/api.py:153-165](https://github.com/tenstorrent/tt-studio/blob/c837b829/inference-api/api.py#L153-L165), [app/frontend/src/components/FirstStepForm.tsx:173-213](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L173-L213)
+
+---
+
+## Domain Concepts
+
+### Retrieval-Augmented Generation (RAG)
+In TT-Studio, RAG is implemented using **ChromaDB** as the vector store [app/docker-compose.yml:164-165](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L164-L165).
+*   **Collection**: A logical grouping of documents within ChromaDB.
+*   **X-Browser-ID**: A unique identifier used to isolate RAG sessions per browser instance.
+*   **Context Injection**: The process where relevant snippets from the vector DB or uploaded text files are retrieved and prepended to the LLM's system message [app/frontend/src/components/chatui/runInference.ts:42-86](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L42-L86).
+
+### Model Types
+The system categorizes models into specific types to determine which UI component and API endpoint to use [app/frontend/src/api/modelsDeployedApis.ts:55-66](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L55-L66):
+*   `ChatModel`: Standard LLM interaction [app/frontend/src/api/modelsDeployedApis.ts:76-77](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L76-L77).
+*   `ObjectDetectionModel`: YOLO-based models that return bounding box coordinates and metadata [app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx:64-66](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/object_detection/ObjectDetectionComponent.tsx#L64-L66).
+*   `VLM`: Vision Language Models capable of processing images via `image_url` message structures [app/frontend/src/components/chatui/runInference.ts:87-106](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L87-L106).
+*   `ImageGeneration`: Diffusion-based image creation (e.g., FLUX.1) [app/frontend/src/components/FirstStepForm.tsx:84-88](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L84-L88).
+*   `TTS` / `SpeechRecognitionModel`: Audio processing pipelines [app/frontend/src/api/modelsDeployedApis.ts:86-91](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L86-L91).
+
+### Hardware Compatibility
+The system performs automated checks to ensure models fit on the detected hardware.
+*   **is_compatible**: A flag returned by the models API indicating if the model supports the current board (e.g., Grayskull vs Wormhole) [app/frontend/src/components/FirstStepForm.tsx:178-185](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L178-L185).
+*   **deviceFit**: Utility logic (e.g., `autoPlacement`, `getModelPlacement`) used to determine if a model's requirements match available chip slots [app/frontend/src/components/FirstStepForm.tsx:41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L41).
+
+### Metrics Tracking
+TT-Studio tracks inference performance using the `InferenceMetricsTracker` [app/backend/model_control/model_utils.py:21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L21).
+*   **InferenceStats**: Data structure containing `ttft`, `tpot`, and `total_tokens` displayed in the Chat UI [app/frontend/src/components/chatui/MessageActions.tsx:9-10](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/MessageActions.tsx#L9-L10).
+
+**Sources:** [app/frontend/src/api/modelsDeployedApis.ts:67-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/api/modelsDeployedApis.ts#L67-L99), [app/frontend/src/components/FirstStepForm.tsx:144-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/FirstStepForm.tsx#L144-L160), [app/frontend/src/components/chatui/runInference.ts:15-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/components/chatui/runInference.ts#L15-L16), [app/backend/model_control/model_utils.py:21](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/model_control/model_utils.py#L21)5:["$","$L15",null,{"repoName":"tenstorrent/tt-studio","hasConfig":false,"canSteer":true,"children":["$","$L16",null,{"wiki":{"metadata":{"repo_name":"tenstorrent/tt-studio","commit_hash":"c837b829","generated_at":"2026-07-17T17:59:06.440858","config":null,"config_source":"none"},"pages":[{"page_plan":{"id":"1","title":"TT-Studio Overview"},"content":"$17"},{"page_plan":{"id":"1.1","title":"Getting Started & Setup"},"content":"$18"},{"page_plan":{"id":"1.2","title":"Architecture Overview"},"content":"$19"},{"page_plan":{"id":"1.3","title":"Contributing & Development Workflow"},"content":"$1a"},{"page_plan":{"id":"2","title":"Backend Services"},"content":"$1b"},{"page_plan":{"id":"2.1","title":"Docker Control & Container Lifecycle"},"content":"$1c"},{"page_plan":{"id":"2.2","title":"Model Control & Inference Pipeline"},"content":"$1d"},{"page_plan":{"id":"2.3","title":"Vector DB Control (RAG Backend)"},"content":"$1e"},{"page_plan":{"id":"2.4","title":"Board Control & Hardware Monitoring"},"content":"$1f"},{"page_plan":{"id":"2.5","title":"Logs Control & Bug Reporting"},"content":"$20"},{"page_plan":{"id":"3","title":"Docker Control Service"},"content":"$21"},{"page_plan":{"id":"3.1","title":"Docker Control Service API & Security"},"content":"$22"},{"page_plan":{"id":"3.2","title":"Inference API (FastAPI Bridge)"},"content":"$23"},{"page_plan":{"id":"4","title":"AI Agent Service"},"content":"$24"},{"page_plan":{"id":"4.1","title":"Agent Architecture & LLM Discovery"},"content":"$25"},{"page_plan":{"id":"4.2","title":"Agent API & Tool Integration"},"content":"$26"},{"page_plan":{"id":"5","title":"Frontend Application"},"content":"$27"},{"page_plan":{"id":"5.1","title":"Application Shell: Routing, Layout & Providers"},"content":"$28"},{"page_plan":{"id":"5.2","title":"Model Deployment UI"},"content":"$29"},{"page_plan":{"id":"5.3","title":"Chat UI"},"content":"$2a"},{"page_plan":{"id":"5.4","title":"RAG Management UI"},"content":"$2b"},{"page_plan":{"id":"5.5","title":"Specialized Model Interfaces"},"content":"$2c"},{"page_plan":{"id":"5.6","title":"Frontend Build, Tooling & UI Component Library"},"content":"$2d"},{"page_plan":{"id":"6","title":"Model Integration & Dummy Echo Model"},"content":"$2e"},{"page_plan":{"id":"6.1","title":"Model Configuration & Catalog"},"content":"$2f"},{"page_plan":{"id":"6.2","title":"Dummy Echo Model Reference Implementation"},"content":"$30"},{"page_plan":{"id":"7","title":"Glossary"},"content":"$31"}]},"children":"$L32"}]}]

--- a/tt-studio/index.md
+++ b/tt-studio/index.md
@@ -1,0 +1,132 @@
+# TT-Studio Overview
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.cursor/rules/project-overview.mdc">.cursor/rules/project-overview.mdc</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md">CLAUDE.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md">README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md">app/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html">app/frontend/index.html</a></li>
+</ul>
+</details>
+
+
+
+TT-Studio is a comprehensive web-based platform designed to simplify the deployment and management of AI models on **Tenstorrent AI accelerators**. It integrates the model execution capabilities of [TT-Metal](https://github.com/tenstorrent-metal/tt-metal) and the orchestration framework of [TT Inference Server](https://github.com/tenstorrent/tt-inference-server) into a unified graphical user interface [README.md:9-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L9-L12).
+
+The system automates technical setup, hardware detection, and containerization, allowing users to interact with large language models (LLMs), computer vision, and speech-to-text pipelines through an intuitive React-based frontend [app/README.md:1-16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L1-L16). For users without local hardware, the platform supports connecting to remote endpoints via "AI Playground" configurations [README.md:11-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L11-L12) [.cursor/rules/project-overview.mdc:15-17](https://github.com/tenstorrent/tt-studio/blob/c837b829/.cursor/rules/project-overview.mdc?plain=1#L15-L17).
+
+## System Architecture & Code Entities
+
+The following diagram illustrates how the logical services of TT-Studio map to specific code entities and network configurations defined in the orchestration layer.
+
+**Service-to-Code Mapping**
+```mermaid
+graph TD
+    subgraph "Frontend Space (Vite/React)"
+        FE["tt_studio_frontend"] -->|Entry| Main["app/frontend/src/main.tsx"]
+        FE -->|Routes| App["app/frontend/src/App.tsx"]
+    end
+
+    subgraph "Backend Space (Django/Uvicorn)"
+        BE["tt_studio_backend"] -->|ASGI| ASGI["app/backend/api/asgi.py"]
+        BE -->|Settings| SET["app/backend/api/settings.py"]
+        BE -->|Models| DB["app/backend/docker_control/models.py"]
+    end
+
+    subgraph "Agent Space (FastAPI)"
+        AG["tt_studio_agent"] -->|Logic| AL["app/agent/main.py"]
+    end
+
+    subgraph "Infrastructure"
+        DCS["docker-control-service"] -->|Port 8002| DC["docker-control-service/"]
+        CH["tt_studio_chroma"] -->|Port 8111| CR["chromadb/chroma:0.5.3"]
+        LT["tt_studio_litellm"] -->|Port 4000| LC["ghcr.io/berriai/litellm"]
+    end
+
+    FE ---|REST/WS| BE
+    BE ---|JWT Auth| DCS
+    BE ---|HTTP| CH
+    BE ---|Proxy| LT
+    AG ---|Polling| BE
+```
+**Sources:** [app/docker-compose.yml:6-160](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L6-L160), [app/frontend/index.html:17-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html#L17-L18), [app/README.md:18-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L18-L19), [CLAUDE.md:28-43](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L28-L43)
+
+---
+
+## Key Capabilities
+
+TT-Studio provides several high-level features for both end-users and developers:
+
+*   **Automated Model Deployment:** Orchestrates the lifecycle of AI models, including weight downloading, container instantiation via the `docker-control-service`, and chip slot allocation [app/docker-compose.yml:61-63](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L61-L63) [CLAUDE.md:29-32](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L29-L32).
+*   **Multi-Modal AI Features:** Built-in support for Chat (LLMs), Image Generation (Stable Diffusion), Speech-to-Text (Whisper), and Object Detection (YOLOv4) [app/docker-compose.yml:42-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L42-L52) [.cursor/rules/project-overview.mdc:46-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/.cursor/rules/project-overview.mdc?plain=1#L46-L52).
+*   **Retrieval-Augmented Generation (RAG):** Integrated ChromaDB vector store for document indexing and semantic search, enabling "chat with your data" capabilities [app/docker-compose.yml:164-186](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L164-L186) [CLAUDE.md:32](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L32).
+*   **Autonomous AI Agent:** A dedicated `tt_studio_agent` service that can perform complex tasks, discover local LLM containers, and execute code [app/docker-compose.yml:106-136](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L136) [app/README.md:15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L15).
+*   **LiteLLM Gateway:** A LiteLLM instance acting as a gateway for coding-agent tasks and upstream LLM providers [app/docker-compose.yml:138-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138-L162).
+
+---
+
+## Logical Subsystems
+
+TT-Studio is composed of several interdependent services networked via the `tt_studio_network` bridge [app/docker-compose.yml:188-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L188-L190) [CLAUDE.md:23-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L23-L25).
+
+**Subsystem Interaction Flow**
+```mermaid
+sequenceDiagram
+    participant User as "User (Browser)"
+    participant FE as "tt_studio_frontend"
+    participant BE as "tt_studio_backend"
+    participant DCS as "docker-control-service"
+    participant AG as "tt_studio_agent"
+
+    User->>FE: Request Model Deploy
+    FE->>BE: POST /api/docker_control/deploy/
+    BE->>DCS: API Call (Start Container)
+    DCS-->>BE: Container ID / Success
+    BE-->>FE: Deployment Started (SSE)
+    AG->>BE: /poll_requests (Discover LLM)
+    BE-->>AG: Active LLM Endpoint
+```
+**Sources:** [app/docker-compose.yml:6-136](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L6-L136), [app/README.md:9-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L9-L18), [CLAUDE.md:14-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L14-L25)
+
+### 1.1 Getting Started & Setup
+The entry point for the project is the `run.py` script. It handles prerequisite checks, hardware detection, environment configuration via `.env`, and offers different modes such as `--dev` for active development (mounting local source for hot-reload) and `--cleanup-all` for a clean slate [README.md:38-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L38-L53) [CLAUDE.md:46-52](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L46-L52).
+For details, see [Getting Started & Setup](overview/getting-started.md).
+
+### 1.2 Architecture Overview
+The system runs as a multi-container Docker topology. It includes a Django backend (port 8000), a React frontend (port 3000), a FastAPI-based `docker-control-service` (port 8002) to proxy host-level operations (replacing direct socket mounts), and ChromaDB (port 8111) for vector storage [app/docker-compose.yml:5-186](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L5-L186) [CLAUDE.md:14-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L14-L25).
+For details, see [Architecture Overview](overview/architecture.md).
+
+### 1.3 Contributing & Development Workflow
+TT-Studio follows a structured contribution process, including branching strategies (branch off `dev`) and mandatory SPDX license headers. The workflow includes tools for checking and adding headers to maintain codebase compliance [README.md:63-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L63-L64) [CLAUDE.md:59-71](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L59-L71).
+For details, see [Contributing & Development Workflow](overview/contributing.md).
+
+---
+
+## Configuration & Environment
+The system relies on an `.env` file (managed via `run.py`) to handle critical paths and secrets. Key variables include:
+*   **TT_STUDIO_ROOT**: Absolute path to the repository root [app/docker-compose.yml:37](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L37).
+*   **HOST_PERSISTENT_STORAGE_VOLUME**: Location for database and model weight persistence on the host machine [app/docker-compose.yml:38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L38).
+*   **DOCKER_CONTROL_SERVICE_URL**: Endpoint for the secure Docker operations proxy, typically `http://host.docker.internal:8002` [app/docker-compose.yml:62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L62).
+*   **JWT_SECRET**: Used for authenticating internal service communication [app/docker-compose.yml:41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L41).
+*   **LITELLM_MASTER_KEY**: Authentication key for the LiteLLM gateway [app/docker-compose.yml:65](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L65).
+*   **HF_TOKEN**: Hugging Face token for downloading gated models [CLAUDE.md:75-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L75-L76).
+
+**Sources:** [app/docker-compose.yml:30-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L30-L67), [app/README.md:79-81](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L79-L81), [CLAUDE.md:73-80](https://github.com/tenstorrent/tt-studio/blob/c837b829/CLAUDE.md?plain=1#L73-L80)
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+overview/getting-started
+overview/architecture
+overview/contributing
+backend/index
+docker-control-service/index
+agent/index
+frontend/index
+model-integration/index
+glossary
+```

--- a/tt-studio/make.bat
+++ b/tt-studio/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tt-studio/model-integration/config-and-catalog.md
+++ b/tt-studio/model-integration/config-and-catalog.md
@@ -1,0 +1,138 @@
+# Model Configuration & Catalog
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py">app/backend/docker_control/deployment_sync.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py">app/backend/logs_control/views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py">app/backend/shared_config/coding_agent_config.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json">app/backend/shared_config/models_from_inference_server.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py">app/backend/shared_config/sync_models_from_inference_server.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/test_sync_models.py">app/backend/shared_config/test_sync_models.py</a></li>
+</ul>
+</details>
+
+
+
+This page details the configuration schema and cataloging system used by TT-Studio to define, discover, and deploy AI models. The system relies on a central dataclass for model metadata and a JSON-based catalog derived from the Tenstorrent inference server artifacts.
+
+## ModelImpl Dataclass
+
+The `ModelImpl` class is the core configuration entity for any model implementation in TT-Studio. It is a frozen dataclass that defines the static properties required to instantiate a model container, including hardware requirements and Docker runtime parameters.
+
+### Key Fields
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `image_name` | `str` | The Docker image repository (e.g., `ghcr.io/tenstorrent/...`). [app/backend/shared_config/model_config.py:49](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L49) |
+| `image_tag` | `str` | The specific version tag of the Docker image. [app/backend/shared_config/model_config.py:50](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L50) |
+| `device_configurations` | `Set[DeviceConfigurations]` | A set of supported hardware layouts (e.g., `N150`, `T3K`, `GALAXY`). [app/backend/shared_config/model_config.py:51](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L51) |
+| `docker_config` | `Dict[str, Any]` | Runtime parameters passed to the Docker Engine (environment variables, shm_size). [app/backend/shared_config/model_config.py:52](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L52) |
+| `service_route` | `str` | The API endpoint for inference (e.g., `/v1/chat/completions`). [app/backend/shared_config/model_config.py:53](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L53) |
+| `setup_type` | `SetupTypes` | Defines how the model is provisioned (e.g., `TT_INFERENCE_SERVER`). [app/backend/shared_config/model_config.py:54](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L54) |
+| `model_type` | `ModelTypes` | Categorization of the model (e.g., `CHAT`, `IMAGE_GENERATION`). [app/backend/shared_config/model_config.py:55](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L55) |
+| `hf_model_id` | `str` | The HuggingFace repository ID for weight downloading. [app/backend/shared_config/model_config.py:56](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L56) |
+| `shm_size` | `str` | Shared memory allocation, defaults to `32G` for Tenstorrent workloads. [app/backend/shared_config/model_config.py:61](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L61) |
+
+### Initialization Logic
+During `__post_init__`, the class performs several derived configuration steps:
+1.  **Volume Mapping**: Automatically configures host-to-container volume mounts for model weights and HuggingFace caches [app/backend/shared_config/model_config.py:73-79](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L73-L79).
+2.  **Hardware Specifics**: If the configuration includes Wormhole-based architectures (`N150_WH_ARCH_YAML`, `N300_WH_ARCH_YAML`, or `N300x4_WH_ARCH_YAML`), it injects the `WH_ARCH_YAML` environment variable set to `wormhole_b0_80_arch_eth_dispatch.yaml` [app/backend/shared_config/model_config.py:81-89](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L81-L89).
+3.  **Environment Overrides**: Loads model-specific `.env` files from the persistent storage volume via `load_dotenv_dict` to override default Docker environment variables [app/backend/shared_config/model_config.py:91-99](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L91-L99).
+
+**Sources:**
+- `ModelImpl` definition: [app/backend/shared_config/model_config.py:44-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L67)
+- `__post_init__` logic: [app/backend/shared_config/model_config.py:69-100](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L69-L100)
+
+## Model Catalog
+
+The system maintains a primary catalog file, `models_from_inference_server.json`, which acts as the source of truth for available models. This file is generated from the `tt-inference-server` project and contains metadata for over 50 models [app/backend/shared_config/models_from_inference_server.json:1-7](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L1-L7).
+
+### Catalog Synchronization
+The catalog is updated via the `sync_models_from_inference_server.py` script. This script performs several normalization tasks:
+- **Source Resolution**: Locates `model_specs_output.json` from artifact paths (via `TT_INFERENCE_ARTIFACT_PATH`) or local dev checkouts [app/backend/shared_config/sync_models_from_inference_server.py:38-61](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L38-L61).
+- **Route Derivation**: Uses `map_service_route` to determine if a model should use OpenAI-compatible endpoints like `/v1/chat/completions`, `/v1/audio/speech`, or `/v1/images/generations` based on its engine and type [app/backend/shared_config/sync_models_from_inference_server.py:128-157](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L128-L157).
+- **Environment Filtering**: Strips device-specific environment variables (like `WH_ARCH_YAML`, `MESH_DEVICE`, `ARCH_NAME`) that are handled dynamically by `ModelImpl.__post_init__` [app/backend/shared_config/sync_models_from_inference_server.py:174-186](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L174-L186).
+- **Health Check Mapping**: All models (vLLM, forge, media) are normalized to use `/health` as their health route [app/backend/shared_config/sync_models_from_inference_server.py:160-172](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L160-L172).
+
+### Natural Language to Code Entity Mapping: Model Discovery
+The following diagram illustrates how user-facing model names in the UI are resolved to specific `ModelImpl` instances and Docker configurations.
+
+Title: Model Discovery and Resolution Flow
+```mermaid
+graph TD
+    User["User Selection (UI)"] -- "model_name" --> Catalog["models_from_inference_server.json"]
+    Catalog -- "JSON Object" --> Factory["ModelConfig Factory"]
+    Factory -- "Instantiates" --> ModelImpl["ModelImpl Class"]
+    
+    subgraph "app/backend/shared_config/model_config.py"
+        ModelImpl
+        LoadEnv["load_dotenv_dict()"]
+        PostInit["__post_init__()"]
+    end
+    
+    ModelImpl -- "triggers" --> PostInit
+    PostInit -- "calls" --> LoadEnv
+    LoadEnv -- "updates" --> Docker["docker_config['environment']"]
+    
+    style ModelImpl stroke-width:2px
+    style Catalog stroke-dasharray: 5 5
+```
+**Sources:**
+- Catalog data: [app/backend/shared_config/models_from_inference_server.json:7-133](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L7-L133)
+- Configuration logic: [app/backend/shared_config/model_config.py:44-100](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L100)
+- Sync logic: [app/backend/shared_config/sync_models_from_inference_server.py:128-186](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L128-L186)
+
+## Device Configurations & Chip Requirements
+
+TT-Studio infers chip requirements by intersecting the model's `device_configurations` with the system's detected hardware.
+
+### Setup Types and Hardware Layouts
+- **SetupTypes**: Defines the deployment backend (e.g., `TT_INFERENCE_SERVER`) [app/backend/shared_config/model_config.py:54](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L54).
+- **DeviceConfigurations**: Maps to specific Tenstorrent board layouts.
+    - `N150`: Single Wormhole chip [app/backend/shared_config/models_from_inference_server.json:13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L13).
+    - `N300`: Dual Wormhole chips [app/backend/shared_config/models_from_inference_server.json:15](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L15).
+    - `T3K`: Quad-chip configuration [app/backend/shared_config/models_from_inference_server.json:19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L19).
+    - `GALAXY`: High-density cluster [app/backend/shared_config/models_from_inference_server.json:13](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L13).
+    - `P300x2`: Dual Blackhole configuration [app/backend/shared_config/models_from_inference_server.json:18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L18).
+
+### Model ID and Naming
+The `ModelImpl` class automatically generates a `model_id` if not provided, using the format `id_{impl_id}-{model_name}-v{version}` [app/backend/shared_config/model_config.py:152-153](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L152-L153). It also defaults the `model_name` to the basename of the `hf_model_id` if the name is missing [app/backend/shared_config/model_config.py:144-146](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L144-L146).
+
+### Natural Language to Code Entity Mapping: Path Resolution
+This diagram shows how `ModelImpl` properties resolve host paths to container paths for persistent storage.
+
+Title: Model Storage Path Resolution
+```mermaid
+graph LR
+    ModelImpl["ModelImpl Instance"] -- "host_path" --> HostDir["/opt/tt_studio/data/volume_{model_id}"]
+    ModelImpl -- "volume_path" --> VolDir["/app/data/volume_{model_id}"]
+    
+    subgraph "Docker Volume Mapping"
+        HostDir -- "binds to" --> ContDir["model_container_cache_root"]
+    end
+    
+    ModelImpl -- "get_volume_mounts()" --> Mounts["docker_config['volumes']"]
+    Mounts -- "defines" --> HostDir
+```
+**Sources:**
+- Path properties: [app/backend/shared_config/model_config.py:105-139](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L105-L139)
+- Volume mounting: [app/backend/shared_config/model_config.py:170-186](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L170-L186)
+
+## Model Environment Management
+
+Model implementations often require specific environment variables for tuning (e.g., `VLLM_RPC_TIMEOUT`). TT-Studio manages these through a tiered system:
+
+1.  **Catalog Defaults**: Defined in the `env_vars` section of `models_from_inference_server.json`. Values are coerced to strings during synchronization to ensure compatibility with Docker environment configuration [app/backend/shared_config/sync_models_from_inference_server.py:174-186](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L174-L186).
+2.  **Persistent Overrides**: The `ModelImpl.get_model_env_file()` function searches for a file named `{model_name}.env` in the `model_envs` directory within the persistent storage volume [app/backend/shared_config/model_config.py:155-168](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L155-L168).
+3.  **JWT Secret Protection**: The system explicitly excludes `JWT_SECRET` from model-specific env files during loading to ensure the global `tt-studio` secret is used for inter-service authentication [app/backend/shared_config/model_config.py:25-26, 38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L25-L26).
+4.  **Coding Agent & Reasoning**: 
+    - Models eligible for coding-agent native tool calling (e.g., `Qwen3-32B`, `Llama-3.3-70B-Instruct`) are defined in `CODING_AGENT_ELIGIBLE_MODELS` [app/backend/shared_config/coding_agent_config.py:13-18](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py#L13-L18).
+    - Reasoning models like `Qwen3-32B` can be deployed with a specific reasoning parser (e.g., `qwen3`) to split reasoning into `reasoning_content` [app/backend/shared_config/coding_agent_config.py:23-27](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py#L23-L27).
+    - The system supports a `-thinking` suffix for requested gateway models to enable reasoning mode [app/backend/shared_config/coding_agent_config.py:31, 62-70](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py#L31).
+
+**Sources:**
+- Environment loading: [app/backend/shared_config/model_config.py:21-40](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L21-L40)
+- Env file discovery: [app/backend/shared_config/model_config.py:155-168](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L155-L168)
+- Catalog Env Vars: [app/backend/shared_config/models_from_inference_server.json:114-119](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L114-L119)
+- Coding Agent Config: [app/backend/shared_config/coding_agent_config.py:10-71](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/coding_agent_config.py#L10-L71)30:T1d9e,# Dummy Echo Model Reference Implementation

--- a/tt-studio/model-integration/dummy-echo-model.md
+++ b/tt-studio/model-integration/dummy-echo-model.md
@@ -1,0 +1,118 @@
+# Dummy Echo Model Reference Implementation
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile">models/dummy_echo_model/Dockerfile</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py">models/dummy_echo_model/src/dummy_echo_backend.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py">models/dummy_echo_model/src/inference_api_server.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py">models/dummy_echo_model/src/inference_config.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/model_weights_handler.py">models/dummy_echo_model/src/model_weights_handler.py</a></li>
+</ul>
+</details>
+
+
+
+The `dummy_echo_model` serves as the reference implementation and template for integrating new AI models into TT-Studio. It provides a complete, containerized inference environment that simulates the behavior of a Large Language Model (LLM) while running on CPU. This allows developers to test the full deployment pipeline, streaming UI, and backend orchestration without requiring Tenstorrent hardware.
+
+## System Architecture
+
+The reference implementation is split into two primary processes to simulate a real-world inference server: a **Flask-based API Server** and a **Multiprocessing Backend**.
+
+### Process Topology and Data Flow
+
+The `inference_api_server.py` initializes a separate `multiprocessing.Process` to run the `run_backend` function [models/dummy_echo_model/src/inference_api_server.py:115-124](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L115-L124). Communication between these processes occurs via thread-safe `multiprocessing.Queue` objects [models/dummy_echo_model/src/inference_api_server.py:111-113](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L111-L113).
+
+Title: "Dummy Echo Model Process Communication"
+```mermaid
+graph TD
+    subgraph "Flask_API_Process[Flask API Process]"
+        A["inference_api_server.py"]
+        B["output_queue_map"]
+        C["respond_to_users_thread"]
+        D["status_func_thread"]
+    end
+
+    subgraph "Inference_Backend_Process[Inference Backend Process]"
+        E["run_backend"]
+        F["DummyEchoBackend_Class"]
+    end
+
+    G["input_queue_MP"]
+    H["output_queue_MP"]
+    I["status_queue_MP"]
+
+    A -- "put(prompt)" --> G
+    G -- "get()" --> E
+    E -- "put(token)" --> H
+    H -- "get()" --> C
+    C -- "store token" --> B
+    E -- "put(metrics)" --> I
+    I -- "get()" --> D
+```
+Sources: [models/dummy_echo_model/src/inference_api_server.py:111-124](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L111-L124), [models/dummy_echo_model/src/inference_api_server.py:195-205](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L195-L205), [models/dummy_echo_model/src/dummy_echo_backend.py:160-165](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L160-L165)
+
+## Key Components
+
+### 1. Inference Configuration (`inference_config.py`)
+The configuration uses `namedtuple` to define model parameters, hardware requirements, and environment-driven settings [models/dummy_echo_model/src/inference_config.py:18-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L18-L53). It handles the mapping of environment variables (like `CACHE_ROOT` and `SERVICE_PORT`) to internal configuration objects [models/dummy_echo_model/src/inference_config.py:58-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L58-L64).
+
+| Parameter | Role |
+| :--- | :--- |
+| `max_input_qsize` | Limits backpressure on the input queue [models/dummy_echo_model/src/inference_config.py:70](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L70). |
+| `max_inactive_seconds` | Time before a user session is considered stale [models/dummy_echo_model/src/inference_config.py:72](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L72). |
+| `end_of_sequence_str` | The token used to signal completion (`<|endoftext|>`) [models/dummy_echo_model/src/inference_config.py:83](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L83). |
+| `ModelConfig` | Defines batch size, sequence length, and sampling defaults [models/dummy_echo_model/src/inference_config.py:42-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L42-L53). |
+
+Sources: [models/dummy_echo_model/src/inference_config.py:18-40](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L18-L40), [models/dummy_echo_model/src/inference_config.py:66-93](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_config.py#L66-L93)
+
+### 2. Flask API Server (`inference_api_server.py`)
+The server manages the lifecycle of the backend process and provides the REST interface for inference.
+
+*   **NUMA Awareness**: To simulate performance optimization, the server parses the system `cpulist` [models/dummy_echo_model/src/inference_api_server.py:70-92](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L70-L92) and pins the backend process to NUMA node 0 while keeping the Flask API on other cores [models/dummy_echo_model/src/inference_api_server.py:125-136](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L125-L136).
+*   **Garbage Collection**: The `_garbage_collection` function periodically reclaims resources for inactive `user_ids` from the `output_queue_map` [models/dummy_echo_model/src/inference_api_server.py:153-182](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L153-L182).
+*   **Warmup**: Upon initialization, it sends a dummy prompt (`COMPILE-INITIALIZATION`) to the backend to trigger any "just-in-time" compilation or weight loading [models/dummy_echo_model/src/inference_api_server.py:33](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L33), [models/dummy_echo_model/src/inference_api_server.py:141-146](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L141-L146).
+
+Sources: [models/dummy_echo_model/src/inference_api_server.py:102-140](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L102-L140), [models/dummy_echo_model/src/inference_api_server.py:33-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L33-L38)
+
+### 3. Dummy Echo Backend (`dummy_echo_backend.py`)
+The `DummyEchoBackend` class simulates a multi-user LLM engine.
+
+*   **Simulation Logic**: It mimics a specific Tokens-Per-Second (TPS) rate by using `time.sleep(1.0 / tokens_per_second)` [models/dummy_echo_model/src/dummy_echo_backend.py:147-148](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L147-L148).
+*   **Token Generation**: It "generates" tokens by slicing the input prompt and returning chunks of characters (simulating 3 chars per token) until the prompt is exhausted [models/dummy_echo_model/src/dummy_echo_backend.py:146-159](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L146-L159).
+*   **User Management**: It maintains a fixed-size list of `UserInfo` objects (default 32 slots) to track concurrent requests [models/dummy_echo_model/src/dummy_echo_backend.py:46-50](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L46-L50).
+
+Title: "Backend Logic Flow"
+```mermaid
+flowchart TD
+    Start["run_backend"] --> Init["Initialize_DummyEchoBackend"]
+    Init --> Loop["Main_Loop"]
+    Loop --> Pick["pick_prompts_method"]
+    Pick --> Decode["decode_method_Simulate_TPS"]
+    Decode --> Push["push_outputs_method"]
+    Push --> Update["update_users_method"]
+    Update --> Status["send_status_method"]
+    Status --> Loop
+```
+Sources: [models/dummy_echo_model/src/dummy_echo_backend.py:124-143](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L124-L143), [models/dummy_echo_model/src/dummy_echo_backend.py:144-159](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L144-L159), [models/dummy_echo_model/src/dummy_echo_backend.py:186-196](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L186-L196)
+
+### 4. Weights Handler (`model_weights_handler.py`)
+Even though this is a dummy model, it implements the `get_model_weights_and_tt_cache_paths` function [models/dummy_echo_model/src/model_weights_handler.py:22](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/model_weights_handler.py#L22). This demonstrates how a real model should resolve paths for weights and the `tt_metal` binary cache based on `MODEL_WEIGHTS_ID` and `MODEL_WEIGHTS_PATH` environment variables [models/dummy_echo_model/src/model_weights_handler.py:32-61](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/model_weights_handler.py#L32-L61).
+
+Sources: [models/dummy_echo_model/src/model_weights_handler.py:32-48](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/model_weights_handler.py#L32-L48), [models/dummy_echo_model/src/model_weights_handler.py:22-61](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/model_weights_handler.py#L22-L61)
+
+## Containerization
+
+The model is packaged using a multi-stage `Dockerfile`.
+
+*   **Base Image**: `ubuntu:20.04` [models/dummy_echo_model/Dockerfile:6](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L6).
+*   **Execution**: It runs via `gunicorn` [models/dummy_echo_model/Dockerfile:60](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L60).
+*   **Health Check**: A `curl` based health check monitors the service on the configured `SERVICE_PORT` (default 7000) [models/dummy_echo_model/Dockerfile:63-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L63-L64).
+
+Sources: [models/dummy_echo_model/Dockerfile:59-60](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L59-L60), [models/dummy_echo_model/Dockerfile:63-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L63-L64)
+
+## Testing
+
+A standalone test script `test_dummy_backend.py` is provided to verify the backend logic without starting the Flask server. It manually pushes prompts into the `prompt_q` and executes `run_backend` to ensure tokens are generated and the sequence completes.
+
+Sources: [models/dummy_echo_model/src/dummy_echo_backend.py:124-143](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L124-L143), [models/dummy_echo_model/src/dummy_echo_backend.py:144-159](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/dummy_echo_backend.py#L144-L159)31:T2626,# Glossary

--- a/tt-studio/model-integration/index.md
+++ b/tt-studio/model-integration/index.md
@@ -1,0 +1,112 @@
+# Model Integration & Dummy Echo Model
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py">app/backend/docker_control/deployment_sync.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/logs_control/views.py">app/backend/logs_control/views.py</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json">app/backend/shared_config/models_from_inference_server.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile">models/dummy_echo_model/Dockerfile</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py">models/dummy_echo_model/src/inference_api_server.py</a></li>
+</ul>
+</details>
+
+
+
+This section provides an overview of how AI models are integrated into the TT-Studio ecosystem. Integration is driven by a standardized configuration schema that allows the TT-Studio backend to manage the lifecycle of containerized inference servers, handle hardware requirements for Tenstorrent chips, and provide a unified API for the frontend.
+
+## Model Integration Overview
+
+Models in TT-Studio are treated as independent, containerized services. The integration relies on two primary components:
+1.  **Model Implementation (`ModelImpl`)**: A Python dataclass that defines the static configuration of a model, including its Docker image, environment variables, and hardware compatibility [app/backend/shared_config/model_config.py:44-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L67).
+2.  **Model Catalog**: A JSON-based registry (`models_from_inference_server.json`) that lists all available models and their specific deployment parameters, such as `device_configurations` and `inference_engine` [app/backend/shared_config/models_from_inference_server.json:7-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L7-L38).
+
+The catalog is maintained via a synchronization script, `sync_models_from_inference_server.py`, which normalizes specs from the `tt-inference-server` artifacts into the Studio's format [app/backend/shared_config/sync_models_from_inference_server.py:5-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L5-L11).
+
+The following diagram illustrates how natural language model definitions are mapped to the codebase entities that manage them.
+
+**Model Integration: From Concept to Code**
+```mermaid
+graph TD
+    subgraph "Natural_Language_Space"
+        A["'Llama 3.1 8B Model'"]
+        B["'Wormhole N150 Support'"]
+        C["'Inference Server Image'"]
+    end
+
+    subgraph "Code_Entity_Space"
+        D["ModelImpl_Class"]
+        E["DeviceConfigurations_Enum"]
+        F["models_from_inference_server.json"]
+        G["docker_control_app"]
+        H["sync_models_from_inference_server.py"]
+    end
+
+    A -->|"Registered_in"| F
+    F -->|"Instantiates"| D
+    B -->|"Defined_by"| E
+    D -->|"Includes"| E
+    C -->|"Stored_in"| D
+    D -->|"Consumed_by"| G
+    H -->|"Generates"| F
+```
+
+Sources: [app/backend/shared_config/model_config.py:44-67](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L44-L67), [app/backend/shared_config/models_from_inference_server.json:7-38](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L7-L38), [app/backend/shared_config/device_config.py:11-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/device_config.py#L11-L11), [app/backend/shared_config/sync_models_from_inference_server.py:22-22](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/sync_models_from_inference_server.py#L22-L22).
+
+---
+
+## Model Configuration & Catalog
+
+The `ModelImpl` class is the central configuration object for any model integrated into TT-Studio. It encapsulates metadata such as `image_name`, `service_route`, and `device_configurations` [app/backend/shared_config/model_config.py:49-55](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L49-L55). This configuration is used to dynamically generate Docker deployment parameters, including volume mounts for HuggingFace caches and Tenstorrent device dispatch headers [app/backend/shared_config/model_config.py:73-88](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/model_config.py#L73-L88).
+
+The catalog `models_from_inference_server.json` provides the source of truth for supported models like `distil-large-v3`, `Llama-3.1-8B-Instruct`, or `mochi-1-preview`, specifying their `setup_type`, `model_type`, and `docker_image` [app/backend/shared_config/models_from_inference_server.json:8-192](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/shared_config/models_from_inference_server.json#L8-L192). When models are deployed, the `deployment_sync.py` module manages the transition from a `starting` state to `running` by polling the inference API and updating the `ModelDeployment` record [app/backend/docker_control/deployment_sync.py:5-54](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L5-L54).
+
+For details on schema fields, chip requirement inference, and the model catalog, see **[Model Configuration & Catalog](config-and-catalog.md)**.
+
+---
+
+## Dummy Echo Model Reference Implementation
+
+To facilitate the development of new model integrations, TT-Studio provides a reference implementation called the `dummy_echo_model`. This is a fully functional, containerized Flask application that simulates an LLM's behavior by "echoing" input text back to the user at a controlled tokens-per-second (TPS) rate.
+
+The reference implementation demonstrates:
+*   **Multiprocessing Architecture**: Separating the Flask API server from the "inference" backend using `multiprocessing.Process` to prevent blocking the request handling thread [models/dummy_echo_model/src/inference_api_server.py:115-124](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L115-L124).
+*   **Resource Management**: Using `psutil` to pin the backend process to specific NUMA nodes for performance isolation and setting process `niceness` [models/dummy_echo_model/src/inference_api_server.py:126-140](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L126-L140).
+*   **Standardized API**: Implementing `/health` checks and inference routes that match the TT-Studio expectations for container health monitoring [models/dummy_echo_model/Dockerfile:64-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L64-L64).
+*   **Dockerization**: A complete `Dockerfile` that sets up a Python environment, installs requirements, and runs the service via `gunicorn` [models/dummy_echo_model/Dockerfile:50-60](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L50-L60).
+
+**Reference Implementation Component Mapping**
+```mermaid
+graph LR
+    subgraph "External_Interface"
+        API["inference_api_server.py"]
+        GNC["gunicorn.conf.py"]
+        DKR["Dockerfile"]
+    end
+
+    subgraph "Internal_Logic"
+        BND["dummy_echo_backend.py"]
+        CFG["inference_config.py"]
+        WGT["model_weights_handler.py"]
+    end
+
+    DKR -->|"Starts"| GNC
+    GNC -->|"Wraps"| API
+    API -->|"Reads"| CFG
+    API -->|"Spawns"| BND
+    BND -->|"Simulates_Inference"| BND
+    BND -->|"Uses"| WGT
+```
+
+For a step-by-step breakdown of the reference implementation and how to use it as a template, see **[Dummy Echo Model Reference Implementation](dummy-echo-model.md)**.
+
+Sources: [models/dummy_echo_model/src/inference_api_server.py:115-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/src/inference_api_server.py#L115-L150), [models/dummy_echo_model/Dockerfile:50-64](https://github.com/tenstorrent/tt-studio/blob/c837b829/models/dummy_echo_model/Dockerfile#L50-L64), [app/backend/docker_control/deployment_sync.py:47-54](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/docker_control/deployment_sync.py#L47-L54).2f:T288e,# Model Configuration & Catalog
+
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+config-and-catalog
+dummy-echo-model
+```

--- a/tt-studio/overview/architecture.md
+++ b/tt-studio/overview/architecture.md
@@ -1,0 +1,122 @@
+# Architecture Overview
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.vscode/extensions.json">.vscode/extensions.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.vscode/settings.json">.vscode/settings.json</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md">README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md">app/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile">app/backend/Dockerfile</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html">app/frontend/index.html</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/litellm/config.yaml">app/litellm/config.yaml</a></li>
+</ul>
+</details>
+
+
+
+TT-Studio is built as a distributed multi-service system orchestrated via Docker. It bridges high-level user interactions (web UI, AI agents) with low-level hardware execution on Tenstorrent AI accelerators. The architecture follows a microservices pattern where specific responsibilities—such as Docker lifecycle management, vector search, and model inference—are isolated into distinct containers.
+
+## Multi-Service Topology
+
+The system is defined by a core `docker-compose.yml` that establishes the networking and dependency graph for the platform [app/docker-compose.yml:5-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L5-L190).
+
+### Core Services
+*   **tt_studio_backend**: A Django-based API (running via Uvicorn) that serves as the central orchestrator. It manages the model catalog, tracks deployment states, and interfaces with the vector database [app/docker-compose.yml:6-24](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L6-L24). It runs with 4 workers and includes a health check at `/up/` [app/docker-compose.yml:24-84](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L24-L84).
+*   **tt_studio_frontend**: A React 18 application built with Vite. It provides the user interface for model deployment, RAG management, and interactive chat [app/docker-compose.yml:95-105](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L95-L105).
+*   **tt_studio_agent**: A FastAPI service hosting a LangChain-based autonomous agent that can discover local LLMs and execute tools like Tavily search [app/docker-compose.yml:106-136](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L106-L136).
+*   **tt_studio_chroma**: A ChromaDB instance (v0.5.3) used for vector storage and semantic retrieval (RAG) [app/docker-compose.yml:164-189](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L164-L189). It persists data to the host volume at `/chroma/chroma` [app/docker-compose.yml:170](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L170).
+*   **tt_studio_litellm**: A LiteLLM gateway that provides an OpenAI/Anthropic compatible surface for coding agents, routing requests back to the Django backend [app/docker-compose.yml:138-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138-L162).
+*   **docker-control-service**: A security-hardened FastAPI service running on the **host** (port 8002). It acts as a proxy for Docker socket operations, allowing the backend to manage containers without mounting `/var/run/docker.sock` directly into the backend container [app/README.md:18-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L18-L19).
+
+### Networking & Storage
+All services communicate over a dedicated bridge network named `tt_studio_network` [app/docker-compose.yml:19-20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L19-L20). Persistence is handled via host-mounted volumes defined by `HOST_PERSISTENT_STORAGE_VOLUME`, which stores ChromaDB data and backend application state [app/docker-compose.yml:69-70](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L69-L70). The backend also mounts `hf_cache` to persist embedding models across restarts [app/docker-compose.yml:76-78](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L76-L78).
+
+**Service Dependency Graph**
+The following diagram illustrates the startup sequence and inter-service dependencies.
+
+```mermaid
+graph TD
+    subgraph "Host Environment"
+        DCS["docker-control-service (Port 8002)"]
+    end
+
+    subgraph "tt_studio_network"
+        CHROMA["tt_studio_chroma (Port 8111)"]
+        BACKEND["tt_studio_backend (Port 8000)"]
+        FRONTEND["tt_studio_frontend (Port 3000)"]
+        AGENT["tt_studio_agent (Port 8080)"]
+        LITELLM["tt_studio_litellm (Port 4000)"]
+        MODELS["Model Containers (Ports 7000+)"]
+    end
+
+    BACKEND -->|Depends on| CHROMA
+    FRONTEND -->|Depends on| BACKEND
+    AGENT -->|Depends on| BACKEND
+    LITELLM -->|Depends on| BACKEND
+    BACKEND -.->|JWT Auth| DCS
+    DCS -->|Manages| MODELS
+    BACKEND -->|API Calls| MODELS
+    LITELLM -->|Routes to| BACKEND
+```
+**Sources:** [app/docker-compose.yml:5-190](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L5-L190), [app/litellm/config.yaml:12-17](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/litellm/config.yaml#L12-L17), [app/README.md:9-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L9-L19)
+
+---
+
+## Data Flow & Service Interdependencies
+
+The architecture utilizes a "Control Plane / Data Plane" split. The Backend and Docker Control Service form the control plane, while individual model containers represent the data plane.
+
+### Model Deployment Flow
+1.  **Request**: The Frontend sends a deployment request to `tt_studio_backend`.
+2.  **Orchestration**: The backend uses its internal logic to communicate with the `docker-control-service` via the `DOCKER_CONTROL_SERVICE_URL` [app/docker-compose.yml:62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L62).
+3.  **Execution**: `docker-control-service` pulls the image and runs the container. If Tenstorrent hardware is present, the `docker-compose.tt-hardware.yml` overlay mounts `/dev/tenstorrent` into the container [app/README.md:28-29](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L28-L29).
+4.  **Logging**: Deployment logs are stored in `.artifacts/tt-inference-server/workflow_logs`, which the backend mounts as read-only to provide status updates to the UI [app/docker-compose.yml:72-73](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L72-L73).
+
+### LiteLLM & Coding Agent Flow
+LiteLLM acts as a protocol translator for external coding assistants (e.g., Cursor, Claude Code). It maps incoming OpenAI or Anthropic requests to the internal Django backend [app/litellm/config.yaml:7-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/litellm/config.yaml#L7-L11).
+
+*   **Upstream Routing**: Requests are routed to `http://tt-studio-backend-api:8000/models/openai/v1` [app/litellm/config.yaml:16](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/litellm/config.yaml#L16).
+*   **Key Management**: Uses `LITELLM_MASTER_KEY` for gateway access and `LITELLM_UPSTREAM_KEY` for authenticating with the backend [app/litellm/config.yaml:17-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/litellm/config.yaml#L17-L25).
+
+**Entity Mapping: Protocol Translation**
+
+```mermaid
+sequenceDiagram
+    participant Client as "Coding Agent (Cursor/Claude)"
+    participant LiteLLM as "tt_studio_litellm"
+    participant BE as "tt_studio_backend (Django)"
+    participant MC as "Model Container (vLLM/Whisper)"
+
+    Client->>LiteLLM: POST /v1/chat/completions (OpenAI Format)
+    Note over LiteLLM: Maps to model_name: "*"
+    LiteLLM->>BE: POST /models/openai/v1/chat/completions
+    BE->>MC: Forward to Inference Port (e.g. 7000)
+    MC-->>BE: Token Stream
+    BE-->>LiteLLM: OpenAI-compatible Stream
+    LiteLLM-->>Client: Final Response
+```
+**Sources:** [app/litellm/config.yaml:12-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/litellm/config.yaml#L12-L25), [app/docker-compose.yml:138-162](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138-L162)
+
+---
+
+## System Configuration & Environment
+
+The architecture is highly configurable via environment variables, typically managed by `run.py` during setup [README.md:43-46](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L43-L46).
+
+| Variable | Role | Implementation |
+| :--- | :--- | :--- |
+| `DOCKER_CONTROL_SERVICE_URL` | Points backend to the host service (usually port 8002) | [app/docker-compose.yml:62](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L62) |
+| `TT_STUDIO_ROOT` | Absolute path for volume mounting and artifact access | [app/docker-compose.yml:37](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L37) |
+| `JWT_SECRET` | Used for backend-to-agent and general service auth | [app/docker-compose.yml:41](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L41) |
+| `DOCKER_CONTROL_JWT_SECRET` | Specifically for authenticating with the host Docker service | [app/docker-compose.yml:63](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L63) |
+| `VITE_ENABLE_DEPLOYED` | Toggles "AI Playground" mode (skips local hardware checks) | [app/backend/Dockerfile:7-9](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L7-L9) |
+
+### Security & Deployment Modes
+The system supports multiple execution modes through Docker Compose overlays [app/README.md:22-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L22-L30):
+1.  **Dev Mode**: Uses `docker-compose.dev-mode.yml` to mount local source code into `tt_studio_backend` and `tt_studio_frontend` for hot-reloading [app/README.md:44-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L44-L51).
+2.  **Hardware Mode**: Uses `docker-compose.tt-hardware.yml` to mount `/dev/tenstorrent` devices. The backend container attempts to install `tt-smi` during build if not in Playground mode [app/backend/Dockerfile:28-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L28-L45).
+3.  **Network Security**: Services are isolated within `tt_studio_network`. The backend uses `extra_hosts` to resolve `host.docker.internal` for communicating with the host-side `docker-control-service` [app/docker-compose.yml:91-93](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L91-L93).
+
+**Sources:** [app/docker-compose.yml:30-68](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L30-L68), [app/README.md:22-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L22-L30), [app/backend/Dockerfile:7-45](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/backend/Dockerfile#L7-L45)1a:T2871,# Contributing & Development Workflow

--- a/tt-studio/overview/contributing.md
+++ b/tt-studio/overview/contributing.md
@@ -1,0 +1,210 @@
+# Contributing & Development Workflow
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/feature-branch-pr/SKILL.md">.claude/skills/feature-branch-pr/SKILL.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md">.claude/skills/license-attribution-compliance/SKILL.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/tt-studio-overview/SKILL.md">.claude/skills/tt-studio-overview/SKILL.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/CODEOWNERS">.github/CODEOWNERS</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/backend-license-checker.yml">.github/workflows/backend-license-checker.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/frontend-lint-license-checker.yml">.github/workflows/frontend-lint-license-checker.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/CODE_OF_CONDUCT.md">CODE_OF_CONDUCT.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md">CONTRIBUTING.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.tt-hardware.yml">app/docker-compose.tt-hardware.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ThemeProvider.tsx">app/frontend/src/providers/ThemeProvider.tsx</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/dev-tools/README.md">dev-tools/README.md</a></li>
+</ul>
+</details>
+
+
+
+This page details the standards, processes, and automated workflows required for contributing to the TT-Studio codebase. It covers branching strategies, versioning, pull request requirements, license compliance tools, and AI assistant configurations.
+
+## Contribution Requirements
+
+All contributions must follow a structured process to ensure stability and traceability.
+
+*   **Issue Tracking**: Before starting work, a feature request or bug report must be filed in the GitHub Issues section [CONTRIBUTING.md:11-13](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L11-L13).
+*   **Pull Requests (PRs)**: All code changes must be submitted via PR and require approval from a maintaining team member and relevant codeowners [CONTRIBUTING.md:16-17, 27-29](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L16-L17).
+*   **Acceptance Criteria**: PRs must pass all criteria mandated in the original issue and satisfy automated GitHub Actions [CONTRIBUTING.md:31-32](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L31-L32).
+*   **Codeowners**: Specific modules have designated owners who must approve changes. For example, `/app/backend/` is owned by `@anirudTT`, `@rnabeelTT`, and `@stisiTT` [.github/CODEOWNERS:29](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/CODEOWNERS#L29).
+
+### Code of Conduct
+Contributors are expected to adhere to the Contributor Covenant, which pledges a harassment-free experience and professional standards of behavior [CODE_OF_CONDUCT.md:1-37](https://github.com/tenstorrent/tt-studio/blob/c837b829/CODE_OF_CONDUCT.md?plain=1#L1-L37).
+
+**Sources:** [CONTRIBUTING.md:11-33](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L11-L33), [CODE_OF_CONDUCT.md:1-37](https://github.com/tenstorrent/tt-studio/blob/c837b829/CODE_OF_CONDUCT.md?plain=1#L1-L37), [.github/CODEOWNERS:1-78](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/CODEOWNERS#L1-L78)
+
+---
+
+## Git Branching Strategy
+
+TT-Studio utilizes a multi-tier branching strategy to separate stable production code from active development and feature experimentation.
+
+### Branching Architecture
+"Natural Language Space" to "Code Entity Space" mapping for Git workflow:
+
+| Branch Type | Name Pattern | Purpose | Merge Strategy |
+| :--- | :--- | :--- | :--- |
+| **Main** | `main` | Holds production-ready tagged code [CONTRIBUTING.md:41](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L41). | Rebase/Squash & Merge [CONTRIBUTING.md:45](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L45). |
+| **Development** | `dev` | Central branch for feature integration and validation [CONTRIBUTING.md:47](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L47). | Squash Merge [CONTRIBUTING.md:50](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L50). |
+| **Feature** | `dev-name/feature` or `dev/issue-num` | Individual developer work [CONTRIBUTING.md:61](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L61). | Squash Merge into `dev` [CONTRIBUTING.md:65](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L65). |
+| **Release Cut** | `rc-vx.x.x` | Preparation for production deployment from `main` [CONTRIBUTING.md:75-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L75-L76). | Rebase/Squash into `main` [CONTRIBUTING.md:93](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L93). |
+
+### Development Workflow Diagram
+
+This diagram illustrates the flow of code from local feature development through validation to production release.
+
+```mermaid
+graph TD
+    subgraph "Feature_Space"
+        F["Feature_Branch (dev-user/feature)"]
+    end
+
+    subgraph "Integration_Space"
+        D["dev_Branch"]
+    end
+
+    subgraph "Release_Space"
+        RC["Release_Cut (rc-vX.X.X)"]
+        M["main_Branch (Production)"]
+    end
+
+    F -- "Squash_Merge (after review)" --> D
+    D -- "Cherry-pick_Validated_Features" --> RC
+    RC -- "Testing_&_Bug_Fixes" --> RC
+    RC -- "Rebase/Squash_Merge (2+_Approvals)" --> M
+    M -- "Git_Tag (Semantic_Version)" --> M
+    
+    style M stroke-width:4px
+```
+
+**Sources:** [CONTRIBUTING.md:39-95](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L39-L95)
+
+---
+
+## Versioning Standards
+
+TT-Studio follows **Semantic Versioning (SemVer)** to track changes and communicate impact to users [CONTRIBUTING.md:105-107](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L105-L107).
+
+*   **MAJOR**: Incremented for breaking changes, such as altering networking designs or modifying backend API flows [CONTRIBUTING.md:109-114](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L109-L114).
+*   **MINOR**: Incremented for backward-compatible new features, such as adding support for new models [CONTRIBUTING.md:116-118](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L116-L118).
+*   **PATCH**: Incremented for backward-compatible bug fixes and minor improvements [CONTRIBUTING.md:122-123](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L122-L123).
+
+**Sources:** [CONTRIBUTING.md:105-125](https://github.com/tenstorrent/tt-studio/blob/c837b829/CONTRIBUTING.md?plain=1#L105-L125)
+
+---
+
+## CI/CD & Automated Checks
+
+The repository uses GitHub Actions to enforce code quality, linting, and licensing requirements on every PR.
+
+### SPDX License Headers
+Every source file must contain SPDX license identifiers to ensure compliance with Apache-2.0.
+*   **Backend Requirement**: Python, Shell, and Dockerfiles must include the header [`.github/workflows/backend-license-checker.yml:52-60`](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/backend-license-checker.yml#L52-L60).
+*   **Frontend Requirement**: JS/TS files must include the header [`.github/workflows/frontend-lint-license-checker.yml:93-94`](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/frontend-lint-license-checker.yml#L93-L94).
+
+**Standard Header Format:**
+```python
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+```
+[`app/frontend/src/providers/ThemeProvider.tsx:1-2`](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ThemeProvider.tsx#L1-L2), [`.github/workflows/backend-license-checker.yml:140-142`](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/backend-license-checker.yml#L140-L142)
+
+### Frontend Linting & License Pipeline
+The `TT-Studio Frontend Linter SPDX Licenses Checker` workflow performs the following sequence:
+
+```mermaid
+sequenceDiagram
+    participant PR as "Pull_Request"
+    participant GH as "GitHub_Actions"
+    participant ES as "ESLint"
+    participant LC as "License_Checker"
+
+    PR->>GH: push / open / synchronize
+    GH->>GH: Fetch_Git_History (Base vs Head)
+    GH->>LC: npm_run_header:check:changed
+    Note over LC: Validates SPDX headers on changed files
+    GH->>GH: Filter_Changed_Frontend_Files (.ts, .tsx, .js, .jsx)
+    GH->>ES: npx_eslint [changed_files]
+    Note over ES: Checks for errors and missing LC headers
+    ES-->>GH: Clean_ANSI_&_Group_Errors
+    GH-->>PR: Fail if Errors or Missing Headers Found
+```
+
+**Key Code Entities:**
+*   **Workflow**: `.github/workflows/frontend-lint-license-checker.yml` [line 1](https://github.com/tenstorrent/tt-studio/blob/c837b829/line 1)
+*   **Header Check Script**: `npm run header:check:changed` [line 59](https://github.com/tenstorrent/tt-studio/blob/c837b829/line 59)
+*   **Linter**: `npx eslint` [line 130](https://github.com/tenstorrent/tt-studio/blob/c837b829/line 130)
+
+**Sources:** [`.github/workflows/frontend-lint-license-checker.yml:1-180`](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/frontend-lint-license-checker.yml#L1-L180), [`.github/workflows/backend-license-checker.yml:1-162`](https://github.com/tenstorrent/tt-studio/blob/c837b829/.github/workflows/backend-license-checker.yml#L1-L162), [`app/frontend/src/providers/ThemeProvider.tsx:1-2`](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/src/providers/ThemeProvider.tsx#L1-L2)
+
+---
+
+## Developer Tools
+
+The `dev-tools/` directory contains utilities to automate compliance and maintenance tasks.
+
+### SPDX Header Tool
+The `add_spdx_header.py` script automatically adds Apache-2.0 license headers to source files [dev-tools/README.md:17-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/dev-tools/README.md?plain=1#L17-L19).
+
+*   **Functionality**: Scans `app/backend/` and `app/frontend/` recursively, applying the correct comment syntax based on file extension [dev-tools/README.md:27-42](https://github.com/tenstorrent/tt-studio/blob/c837b829/dev-tools/README.md?plain=1#L27-L42).
+*   **Safety**: It is safe to run multiple times as it detects existing headers and avoids duplication [dev-tools/README.md:89](https://github.com/tenstorrent/tt-studio/blob/c837b829/dev-tools/README.md?plain=1#L89).
+*   **Usage**: `python3 dev-tools/add_spdx_header.py` [dev-tools/README.md:66](https://github.com/tenstorrent/tt-studio/blob/c837b829/dev-tools/README.md?plain=1#L66).
+
+### License Attribution Gate
+The `check_license_attribution.py` script serves as a deterministic gate in CI to catch mechanical drift in third-party attributions [.claude/skills/license-attribution-compliance/SKILL.md:22-24](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L22-L24).
+
+*   **Frontend Freshness**: Checks if `app/frontend/third-party-licenses.txt` is up to date with `package.json` [.claude/skills/license-attribution-compliance/SKILL.md:48](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L48).
+*   **New Dependency Check**: Flags any newly added dependencies in `requirements.txt` or `package.json` that lack an entry in the root `LICENSE` or an allowlist [.claude/skills/license-attribution-compliance/SKILL.md:45, 79-82](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L45).
+
+**Sources:** [dev-tools/README.md:17-146](https://github.com/tenstorrent/tt-studio/blob/c837b829/dev-tools/README.md?plain=1#L17-L146), [.claude/skills/license-attribution-compliance/SKILL.md:1-135](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L1-L135)
+
+---
+
+## AI Assistant Skill Configurations
+
+For developers using Claude or Cursor, specific "skills" are defined to enforce the repository's professional standards and technical workflows.
+
+### Feature Branch & PR Skill
+Configured in `.claude/skills/feature-branch-pr/SKILL.md`, this skill guides AI assistants through the standard TT-Studio development cycle.
+
+*   **Branching Logic**: Enforces branching off `dev` using the `<username>/<feature>` naming convention [.claude/skills/feature-branch-pr/SKILL.md:21, 59](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/feature-branch-pr/SKILL.md?plain=1#L21).
+*   **Verification**: Mandates running `python run.py --dev` and checking health endpoints (e.g., `localhost:8000/up/`) before committing [.claude/skills/feature-branch-pr/SKILL.md:94-103](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/feature-branch-pr/SKILL.md?plain=1#L94-L103).
+*   **Human-Only Attribution**: Strictly forbids AI-tool attribution (e.g., "Co-authored-by: Claude") in commit messages or PR descriptions [.claude/skills/feature-branch-pr/SKILL.md:28-31](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/feature-branch-pr/SKILL.md?plain=1#L28-L31).
+
+### License Compliance Skill
+Configured in `.claude/skills/license-attribution-compliance/SKILL.md`, this skill provides the judgment layer for third-party assets.
+
+*   **Classification**: Guides the AI to flag NonCommercial (CC BY-NC) or Strong Copyleft (GPL) licenses as blockers [.claude/skills/license-attribution-compliance/SKILL.md:62-70](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L62-L70).
+*   **Bundled Assets**: Requires sidecar `README.md` files for checked-in binaries or weights to document provenance and license inheritance [.claude/skills/license-attribution-compliance/SKILL.md:83-93](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L83-L93).
+
+### Workflow Integration Diagram
+Associating AI skill entities with development commands and checks:
+
+```mermaid
+graph LR
+    subgraph "AI_Assistant_Skills"
+        FBS["feature-branch-pr"]
+        LCS["license-attribution-compliance"]
+    end
+
+    subgraph "Development_Commands"
+        RUN["python_run.py_--dev"]
+        SPDX["python_dev-tools/add_spdx_header.py"]
+        LINT["npm_run_lint"]
+    end
+
+    subgraph "Verification_Endpoints"
+        UP["/up/ (Django)"]
+        HLTH["/health (FastAPI)"]
+    end
+
+    FBS -- "Triggers" --> RUN
+    FBS -- "Verifies_via" --> UP
+    FBS -- "Verifies_via" --> HLTH
+    LCS -- "Uses_Tool" --> SPDX
+    LCS -- "Checks_Drift" --> LINT
+```
+
+**Sources:** [.claude/skills/feature-branch-pr/SKILL.md:1-181](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/feature-branch-pr/SKILL.md?plain=1#L1-L181), [.claude/skills/license-attribution-compliance/SKILL.md:1-135](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/license-attribution-compliance/SKILL.md?plain=1#L1-L135), [.claude/skills/tt-studio-overview/SKILL.md:1-56](https://github.com/tenstorrent/tt-studio/blob/c837b829/.claude/skills/tt-studio-overview/SKILL.md?plain=1#L1-L56)1b:T180d,# Backend Services

--- a/tt-studio/overview/getting-started.md
+++ b/tt-studio/overview/getting-started.md
@@ -1,0 +1,136 @@
+# Getting Started & Setup
+
+<details>
+<summary>Relevant source files</summary>
+<ul>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default">.env.default</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md">README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md">app/README.md</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml">app/docker-compose.yml</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/app/frontend/index.html">app/frontend/index.html</a></li>
+<li><a href="https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py">run.py</a></li>
+</ul>
+</details>
+
+
+
+This page provides a technical guide for setting up and initializing the TT-Studio environment. It covers prerequisites, the execution flow of the primary setup script, environment configuration, and hardware detection mechanisms.
+
+## Prerequisites
+
+Before deploying TT-Studio, the host system must meet specific hardware and software requirements to ensure compatibility with Tenstorrent AI accelerators and Docker-based service orchestration.
+
+*   **Tenstorrent Software Stack**: Drivers and system configuration must be completed following the [Tenstorrent Getting Started Guide](https://docs.tenstorrent.com/getting-started/README.html) [README.md:32-33](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L32-L33).
+*   **Python 3.8+**: Required for running the orchestration script `run.py` [README.md:29](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L29).
+*   **Docker & Docker Compose**: Used for containerizing all subsystems. Users must be added to the `docker` group to allow non-sudo execution: `sudo usermod -aG docker $USER` [README.md:30](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L30).
+*   **Hugging Face Token**: Required for downloading gated models such as Llama [README.md:31](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L31).
+*   **Node.js**: The `run.py` script manages frontend dependencies (`node_modules`) during the setup process [run.py:9](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L9).
+
+**Sources:** [README.md:25-34](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L25-L34), [run.py:7-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L7-L12)
+
+## Setup Orchestration: run.py
+
+The `run.py` script is the unified entry point for TT-Studio. It manages the lifecycle of backend services, environment configuration, and auxiliary services like the `docker-control-service` [run.py:7-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L7-L12).
+
+### Execution Modes
+
+| Mode | Command | Description |
+| :--- | :--- | :--- |
+| **Standard** | `python3 run.py` | Interactive setup that configures `.env`, checks dependencies, and starts containers [README.md:43-46](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L43-L46). |
+| **Dev Mode** | `python3 run.py --dev` | Development mode: mounts local source code for the backend and frontend into containers to enable hot-reloading [README.md:50-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L50-L51), [run.py:17](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L17). |
+| **Cleanup** | `python3 run.py --cleanup` | Stops and removes TT-Studio containers and networks while preserving persistent data [README.md:51-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L51-L53), [run.py:18](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L18). |
+| **Cleanup All** | `python3 run.py --cleanup-all` | Full wipe: removes containers, networks, the persistent volume, and the `.env` file [README.md:51-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L51-L53), [run.py:19](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L19). |
+
+### Startup Data Flow
+
+The following diagram illustrates how `run.py` (Natural Language Space) orchestrates the system components defined in the codebase (Code Entity Space).
+
+**Figure 1: run.py Initialization Logic**
+```mermaid
+graph TD
+    subgraph Host_Space_run_py["run.py"] --> setup_environment["_setup_environment()"]
+        setup_environment["_setup_environment()"] --> create_docker_network_tt_studio_network["_create_docker_network('tt_studio_network')"]
+        create_docker_network_tt_studio_network["_create_docker_network('tt_studio_network')"] --> start_docker_control_service["start_docker_control_service()"]
+        start_docker_control_service["start_docker_control_service()"] --> run_docker_compose["_run_docker_compose()"]
+    end
+
+    subgraph Docker_Topology_tt_studio_network["_run_docker_compose()"] --> tt_studio_backend["tt_studio_backend"]
+        run_docker_compose["_run_docker_compose()"] --> tt_studio_frontend["tt_studio_frontend"]
+        run_docker_compose["_run_docker_compose()"] --> tt_studio_chroma["tt_studio_chroma"]
+        run_docker_compose["_run_docker_compose()"] --> tt_studio_agent["tt_studio_agent"]
+        run_docker_compose["_run_docker_compose()"] --> tt_studio_litellm["tt_studio_litellm"]
+    end
+
+    subgraph Persistence_and_Config["tt_studio_backend"] --- HOST_PERSISTENT_STORAGE_VOLUME["HOST_PERSISTENT_STORAGE_VOLUME"]
+        tt_studio_chroma["tt_studio_chroma"] --- HOST_PERSISTENT_STORAGE_VOLUME["HOST_PERSISTENT_STORAGE_VOLUME"]
+        setup_environment["_setup_environment()"] --- ROOT_env["ROOT/.env"]
+    end
+```
+**Sources:** [run.py:7-25](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L7-L25), [run.py:86-87](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L86-L87), [app/docker-compose.yml:19-20](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L19-L20), [app/docker-compose.yml:164-170](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L164-L170), [.env.default:1-11](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L1-L11)
+
+## Environment Configuration (.env)
+
+TT-Studio uses a single, canonical `.env` file located at the repository root for the whole project. The `run.py` script generates this from `.env.default` if it does not exist [run.py:86-87](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L86-L87), [.env.default:3-5](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L3-L5).
+
+### Key Variables
+*   **`TT_STUDIO_ROOT`**: Absolute path to the repository root, used for volume mounting [.env.default:10](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L10).
+*   **`TT_INFERENCE_ARTIFACT_VERSION`**: Specifies the version of the `tt-inference-server` artifact to deploy (e.g., `v0.17.0`) [.env.default:23](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L23).
+*   **`JWT_SECRET`**: Secret for signing tokens used in service-to-service communication [.env.default:29](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L29).
+*   **`VITE_ENABLE_DEPLOYED`**: Boolean flag that toggles between using local Tenstorrent hardware or remote cloud endpoints for inference [.env.default:64](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L64), [app/docker-compose.yml:57](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L57).
+*   **`DOCKER_CONTROL_SERVICE_URL`**: Points to the host-side proxy for Docker operations, typically `http://host.docker.internal:8002` [.env.default:40](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L40).
+*   **`LITELLM_PORT`**: Host port the LiteLLM gateway is published on, defaulting to 4000 [.env.default:53](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L53), [app/docker-compose.yml:146](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L146).
+*   **`WAKEWORD_MODEL`**: Defines the model used for wake word detection (default: `hey_quiet_box`) [.env.default:100](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L100).
+
+**Sources:** [.env.default:1-110](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L1-L110), [app/docker-compose.yml:30-68](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L30-L68)
+
+## Hardware Detection & Container Mounting
+
+TT-Studio detects Tenstorrent hardware by checking for devices in `/dev/tenstorrent`. When hardware is present, `run.py` includes the `docker-compose.tt-hardware.yml` override during the `docker compose up` command [app/README.md:28-30](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L28-L30), [app/README.md:53-61](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L53-L61).
+
+**Figure 2: Hardware Access & Resource Mapping**
+```mermaid
+graph LR
+    subgraph Host_Resources["/dev/tenstorrent"]
+        HOST_PERSISTENT_STORAGE_VOLUME["HOST_PERSISTENT_STORAGE_VOLUME"]
+        DOCKER_CONTROL_SERVICE_URL_Port_8002["DOCKER_CONTROL_SERVICE_URL_Port_8002"]
+    end
+
+    subgraph tt_studio_backend_Container["uvicorn_api_asgi_application"]
+        dev_tenstorrent_Mapped["/dev/tenstorrent_Mapped"]
+        tt_studio_persistent_volume["/tt_studio_persistent_volume"]
+    end
+
+    dev_tenstorrent["/dev/tenstorrent"] -.->|"docker-compose.tt-hardware.yml"| dev_tenstorrent_Mapped["/dev/tenstorrent_Mapped"]
+    HOST_PERSISTENT_STORAGE_VOLUME["HOST_PERSISTENT_STORAGE_VOLUME"] -.->|"volumes"| tt_studio_persistent_volume["/tt_studio_persistent_volume"]
+    uvicorn_api_asgi_application["uvicorn_api_asgi_application"] -->|"DOCKER_CONTROL_SERVICE_URL"| DOCKER_CONTROL_SERVICE_URL_Port_8002["DOCKER_CONTROL_SERVICE_URL_Port_8002"]
+```
+**Sources:** [app/docker-compose.yml:14-17](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L14-L17), [app/docker-compose.yml:23-24](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L23-L24), [app/docker-compose.yml:62-63](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L62-L63), [app/README.md:53-61](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L53-L61)
+
+## AI Playground & Remote Endpoints
+
+For users without local Tenstorrent hardware, TT-Studio supports an "AI Playground" mode by connecting to external model endpoints. This is configured via the `VITE_ENABLE_DEPLOYED` variable and various `CLOUD_*` environment variables in the `.env` file [.env.default:64-96](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L64-L96).
+
+*   **External Chat**: `CLOUD_CHAT_UI_URL` and `CLOUD_CHAT_UI_AUTH_TOKEN` [.env.default:85-86](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L85-L86).
+*   **Vision/Media**: Supports external URLs for YOLOv4, Speech Recognition, and Stable Diffusion [.env.default:88-95](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L88-L95).
+*   **LiteLLM Gateway**: Acts as a proxy for coding agents, utilizing `LITELLM_MASTER_KEY` and `LITELLM_UPSTREAM_KEY` [.env.default:48-51](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L48-L51).
+
+**Sources:** [.env.default:82-96](https://github.com/tenstorrent/tt-studio/blob/c837b829/.env.default#L82-L96), [README.md:11-12](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L11-L12), [app/docker-compose.yml:138-150](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/docker-compose.yml#L138-L150)
+
+## Cleanup and Reset Commands
+
+To maintain system hygiene or reset the environment, `run.py` provides cleanup options that interface with the Docker daemon and host filesystem.
+
+*   **Standard Cleanup**: `python3 run.py --cleanup`
+    *   Stops all containers and removes the `tt_studio_network`.
+    *   Preserves the `HOST_PERSISTENT_STORAGE_VOLUME` and `.env` file [run.py:18](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L18).
+*   **Full Reset**: `python3 run.py --cleanup-all`
+    *   Removes containers, networks, and images.
+    *   Wipes the `HOST_PERSISTENT_STORAGE_VOLUME` directory and the `.env` file [README.md:51-53](https://github.com/tenstorrent/tt-studio/blob/c837b829/README.md?plain=1#L51-L53), [run.py:19](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L19).
+*   **Manual Cleanup**:
+    If using raw docker-compose, you must pass all active overlays to the `down` command to avoid orphaned services:
+    ```bash
+    docker compose -f app/docker-compose.yml -f app/docker-compose.dev-mode.yml -f app/docker-compose.tt-hardware.yml down
+    ```
+    [app/README.md:65-76](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L65-L76)
+
+**Sources:** [run.py:18-19](https://github.com/tenstorrent/tt-studio/blob/c837b829/run.py#L18-L19), [app/README.md:65-78](https://github.com/tenstorrent/tt-studio/blob/c837b829/app/README.md?plain=1#L65-L78)19:T1eb4,# Architecture Overview

--- a/versions.yml
+++ b/versions.yml
@@ -5,3 +5,4 @@ ttnn:
 tt-metalium:
 syseng:
 cloud-native-support:
+tt-studio:


### PR DESCRIPTION
## Summary
- Add a `tt-studio/` Sphinx project so TT-Studio docs publish at `https://docs.tenstorrent.com/tt-studio/` via the central docs build
- Surface TT-Studio in the Software left-nav, Software overview card grid, and top-nav Software dropdown
- Leave `tenstorrent/tt-studio` unchanged; content is adapted from the existing TT-Studio docs work to use the shared theme/assets in this repo

## Test plan
- [ ] `python build_docs.py` (or `cd tt-studio && make html`) succeeds
- [ ] Open `output/tt-studio/index.html` and confirm overview + mermaid diagrams render
- [ ] Confirm Software sidebar and overview card link to `/tt-studio/`
- [ ] Confirm top-nav Software dropdown includes TT-Studio

Supersedes #193 (nav-only PR).

[TT-Studio-docs-PR198.pdf](https://github.com/user-attachments/files/30765630/TT-Studio-docs-PR198.pdf)

Made with [Cursor](https://cursor.com)