### PR TITLE
New qb2 compliance page+hella edits

### DIFF
--- a/core/_templates/home.html
+++ b/core/_templates/home.html
@@ -703,28 +703,28 @@
         <div class="cards-grid">
           <a href="systems/quietbox/quietbox-bh-2/index.html" class="card">
             <div class="card-img">
-              <img src="_static/home/qb2-setup-hero.jpg" alt="TT-QuietBox™ 2 (Blackhole)" />
+              <img src="_static/home/qb2-setup-hero.jpg" alt="TT-QuietBox® 2 (Blackhole)" />
             </div>
             <div class="card-text">
-              <p class="card-title">TT-QuietBox™ 2 (Blackhole)</p>
+              <p class="card-title">TT-QuietBox® 2 (Blackhole)</p>
               <p class="card-desc">Next-generation liquid-cooled Blackhole workstation.</p>
             </div>
           </a>
           <a href="aibs/blackhole/index.html" class="card">
             <div class="card-img">
-              <img src="_static/home/blackhole.png" alt="Blackhole™" />
+              <img src="_static/home/blackhole.png" alt="Blackhole®" />
             </div>
             <div class="card-text">
-              <p class="card-title">Blackhole™ PCIe Cards</p>
+              <p class="card-title">Blackhole® PCIe Cards</p>
               <p class="card-desc">Infinitely scalable, high-performance AI processing.</p>
             </div>
           </a>
           <a href="systems/quietbox/quietbox-bh/index.html" class="card">
             <div class="card-img">
-              <img src="_static/home/tt-quietbox-bh.png" alt="TT-QuietBox™ (Blackhole)" />
+              <img src="_static/home/tt-quietbox-bh.png" alt="TT-QuietBox® (Blackhole)" />
             </div>
             <div class="card-text">
-              <p class="card-title">TT-QuietBox™ (Blackhole)</p>
+              <p class="card-title">TT-QuietBox® (Blackhole)</p>
               <p class="card-desc">Dead-quiet, liquid-cooled desktop AI.</p>
             </div>
           </a>
@@ -754,10 +754,10 @@
           </a>
           <a href="systems/quietbox/quietbox-wh/index.html" class="card">
             <div class="card-img">
-              <img src="_static/home/tt-quietbox.png" alt="TT-QuietBox™ (Wormhole)" />
+              <img src="_static/home/tt-quietbox.png" alt="TT-QuietBox® (Wormhole)" />
             </div>
             <div class="card-text">
-              <p class="card-title">TT-QuietBox™ (Wormhole)</p>
+              <p class="card-title">TT-QuietBox® (Wormhole)</p>
               <p class="card-desc">Dead-quiet desktop AI.</p>
             </div>
           </a>

--- a/core/aibs/blackhole/index.md
+++ b/core/aibs/blackhole/index.md
@@ -1,20 +1,20 @@
 ---
 myst:
   html_meta:
-    product-name: Blackhole™ AI Processor, Blackhole™ Tensix Processor, Blackhole™ p100a, Blackhole™ p150a, Blackhole™ p150b, Tenstorrent
+    product-name: Blackhole® AI Processor, Blackhole® Tensix Processor, Blackhole® p100a, Blackhole® p150a, Blackhole® p150b, Tenstorrent
     technology-concepts: PCIe, ATX, ESD, QSFP-DD, RISC-V, GDDR6, ASIC, firmware, active cooling, passive cooling, Floating point, Block floating point, Integer, TensorFloat, Vector
     document-type: Product Guide
 ---
 
-# Blackhole™ PCIe Cards
+# Blackhole® PCIe Cards
 
-This page covers everything for Tenstorrent Blackhole™ PCIe cards: how to
+This page covers everything for Tenstorrent Blackhole® PCIe cards: how to
 install and connect them, their full hardware specifications, and answers to
 common hardware questions. Use the page navigation on the right to jump between
 sections.
 
 ## Hardware Installation
-This document guides system administrators and users through the process of physically installing and connecting Tenstorrent Blackhole™ p100a, Blackhole™ p150a, and Blackhole™ p150b add-in boards into a host system. You will learn the necessary pre-installation steps, installation procedures for desktop workstations, and how to connect power.
+This document guides system administrators and users through the process of physically installing and connecting Tenstorrent Blackhole® p100a, Blackhole® p150a, and Blackhole® p150b add-in boards into a host system. You will learn the necessary pre-installation steps, installation procedures for desktop workstations, and how to connect power.
 
 ---
 
@@ -25,8 +25,8 @@ Before you begin the installation process, complete the following steps:
 1. Disconnect power from the host computer.  
 2. Verify that your system meets the following requirements:  
    * **PCI Express 5.0 x16 slot**: For optimal performance, the board requires a x16 configuration without bifurcation.  
-     * Blackhole™ p100a and Blackhole™ p150a products are dual-slot width boards with active coolers. Tenstorrent recommends leaving the adjacent slot unoccupied to ensure optimal airflow.  
-     * Blackhole™ p150b is a dual-slot width board with a passive heatsink, designed for rack-mounted systems with sufficient active airflow.
+     * Blackhole® p100a and Blackhole® p150a products are dual-slot width boards with active coolers. Tenstorrent recommends leaving the adjacent slot unoccupied to ensure optimal airflow.  
+     * Blackhole® p150b is a dual-slot width board with a passive heatsink, designed for rack-mounted systems with sufficient active airflow.
      :::{warning}
      An **ATX 3.1 Certified power supply** or better is required. Using an older or inadequate power supply may result in system instability.  
      :::
@@ -42,7 +42,7 @@ Before you begin the installation process, complete the following steps:
 Images shown might not fully represent your specific system configuration.
 :::
 
-Insert the **Blackhole™** add-in board into the **PCIe x16 slot** and secure it with the necessary screws. (A Blackhole™ p150a is pictured below for reference.)
+Insert the **Blackhole®** add-in board into the **PCIe x16 slot** and secure it with the necessary screws. (A Blackhole® p150a is pictured below for reference.)
 
 ![](./images/bh_d_install.png)
 
@@ -57,7 +57,7 @@ Ensure the power cable is fully and securely connected to prevent instability or
 
 ### Software Setup
 
-For instructions on how to set up software for your Blackhole™ p100a, Blackhole™ p150a, or Blackhole™ p150b, refer to the [Installing the Tenstorrent Software Stack guide.](../../getting-started/README.md)
+For instructions on how to set up software for your Blackhole® p100a, Blackhole® p150a, or Blackhole® p150b, refer to the [Installing the Tenstorrent Software Stack guide.](../../getting-started/README.md)
 
 ---
 
@@ -65,11 +65,11 @@ For instructions on how to set up software for your Blackhole™ p100a, Blackhol
 If you encounter any issues, or have a question that isn't covered in the documentation, please [raise a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
 
 ## Specifications and Requirements
-This document provides detailed technical specifications for the Tenstorrent Blackhole™ Tensix Processor and its associated add-in boards. It is intended for users, system integrators, and developers who require precise information about the hardware capabilities and system requirements for deploying Blackhole-based solutions.
+This document provides detailed technical specifications for the Tenstorrent Blackhole® Tensix Processor and its associated add-in boards. It is intended for users, system integrators, and developers who require precise information about the hardware capabilities and system requirements for deploying Blackhole-based solutions.
 
 
-### Blackhole™ Tensix Processor Overview
-The Tenstorrent Blackhole™ Tensix Processor powers the Blackhole™ p100a, p150a, and p150b cards. The processor features:
+### Blackhole® Tensix Processor Overview
+The Tenstorrent Blackhole® Tensix Processor powers the Blackhole® p100a, p150a, and p150b cards. The processor features:
 
 * Tensix core count: 120  
 * SiFive x280 "Big RISC-V" cores: 16  
@@ -101,7 +101,7 @@ The **p100a** and **p150a** cards are designed for desktop workstations where ac
 | Cooling                   | Active                      | Active                      | Passive                     |
 | Dimensions (WxDxH)        | 42mm x 270mm x 111mm        | 42mm x 270mm x 111mm        | 42mm x 270mm x 111mm        |
 
-**For connecting to Tenstorrent Blackhole™-based cards only.*
+**For connecting to Tenstorrent Blackhole®-based cards only.*
 
 ### Card Dimensions
 
@@ -119,15 +119,15 @@ The **p100a** and **p150a** cards are designed for desktop workstations where ac
 
 ### Connectivity (p150a/p150b)
 
-Blackhole™ PCIe cards feature four QSFP-DD ports for connecting to other cards. *(p150b pictured; p150a will have the same ports.)*
+Blackhole® PCIe cards feature four QSFP-DD ports for connecting to other cards. *(p150b pictured; p150a will have the same ports.)*
 
 ![](./images/bh_portspec.png)
 
-Each of the four passive QSFP-DD ports provides 800 Gbps connectivity and supports cable lengths of up to 2 meters (6.5 feet). These ports connect exclusively to other Blackhole™-based add-in cards.
+Each of the four passive QSFP-DD ports provides 800 Gbps connectivity and supports cable lengths of up to 2 meters (6.5 feet). These ports connect exclusively to other Blackhole®-based add-in cards.
 
 ### Supported Data Precision Formats
 
-The Blackhole™ Tensix Processor supports the following data precision formats:
+The Blackhole® Tensix Processor supports the following data precision formats:
 
 | Format               | Bit Depth (Tensix Cores)                    | Bit Depth (Big RISC-V Cores)    |
 | -------------------- | ------------------------------------------- | ------------------------------- |
@@ -154,7 +154,7 @@ The Blackhole™ Tensix Processor supports the following data precision formats:
 
 ### Environment Specifications
 
-The Blackhole™ Tensix Processor cards are designed to meet these environmental specifications:
+The Blackhole® Tensix Processor cards are designed to meet these environmental specifications:
 
 | Specification               | Requirement               |
 | --------------------------- | ------------------------- |
@@ -164,12 +164,12 @@ The Blackhole™ Tensix Processor cards are designed to meet these environmental
 | Air Flow                    | ≥30 CFM @ up to 35°C/95°F |
 
 ## FAQ and Troubleshooting
-This document assists Tenstorrent users in resolving common issues encountered with Blackhole™ AI Processors. It provides solutions and directs users to appropriate support resources.
+This document assists Tenstorrent users in resolving common issues encountered with Blackhole® AI Processors. It provides solutions and directs users to appropriate support resources.
 
-### **How do I choose between the Tenstorrent Blackhole™ p100a/p150a/p150b?**
+### **How do I choose between the Tenstorrent Blackhole® p100a/p150a/p150b?**
 
-- **p100a:** This card is the economical entry point in the Blackhole™ product stack and exists for users looking to evaluate Tenstorrent technology. It features 28 GB of GDDR6 and an **active cooling solution** that conforms to industry PCI specifications, and is intended for **single card operation** in **conventional desktop systems**.
-- **p150a:** This card provides additional local memory (32 GB) compared to p100a and slightly higher compute density. It also features four passive 800 Gbps QSFP-DD ports used for networking with other Tenstorrent Blackhole™ p150a/p150b cards.  It features an **active cooling solution** that conforms to industry PCI specifications, and is intended for **single- or multi-card operation** in **conventional desktop systems**.
+- **p100a:** This card is the economical entry point in the Blackhole® product stack and exists for users looking to evaluate Tenstorrent technology. It features 28 GB of GDDR6 and an **active cooling solution** that conforms to industry PCI specifications, and is intended for **single card operation** in **conventional desktop systems**.
+- **p150a:** This card provides additional local memory (32 GB) compared to p100a and slightly higher compute density. It also features four passive 800 Gbps QSFP-DD ports used for networking with other Tenstorrent Blackhole® p150a/p150b cards.  It features an **active cooling solution** that conforms to industry PCI specifications, and is intended for **single- or multi-card operation** in **conventional desktop systems**.
 - **p150b:** This card features identical specifications to p150a, but features a **passive cooling solution** that conforms to industry PCI specifications, and is intended for **single- or multi-card operation** in **rack-mounted servers** with **existing high static pressure, forced air cooling**.
 
 ### **What PSU and Connector should I use to connect my Blackhole card?**
@@ -188,42 +188,42 @@ To ensure electrical compatibility and prevent hardware damage, only power cable
 
 Use of older 12VHPWR cables is not recommended, even though they are physically compatible with the 12V-2x6 connector. The 12V-2x6 standard replaced 12VHPWR to reduce the risk of overheating (and melting) associated with improper connector seating.
 
-### **Which QSFP cable(s) should I purchase for my Tenstorrent Blackhole™ cards?**
+### **Which QSFP cable(s) should I purchase for my Tenstorrent Blackhole® cards?**
 
 For standard short-reach setups, validated 0.5m QSFP cables are available directly on the Tenstorrent store [hardware cards page](https://tenstorrent.com/hardware/cards).
 
 If you need 1m cables, we recommend either [Amphenol 1m (3.3 ft.) 800G Passive QSFP-DD (SF-NJYYEK0001-001M)](https://cablesondemand.com/qsfp-dd-direct-attach-cables-200g-400g-800g-dac-1/amphenol-sf-njyyek0001-001m-1m-3-3-800g-qsfp-dd-112g-cable-800-gigabit-ethernet-passive-direct-attach-qsfp-double-density-112g-cable-dual-entry-32-awg-qsfp-dd-112g-to-qsfp-dd-112g-sf-njyyek0001-001m) or [FS 1m (3 ft.) 800G Passive QSFP-DD (QDD-800G-PC01)](https://www.fs.com/products/154259.html?attribute=36923&id=3720628).
 
-### **The idle power consumption of my Tenstorrent Blackhole™ card seems high**
+### **The idle power consumption of my Tenstorrent Blackhole® card seems high**
 
-Blackhole™ AI Processors typically consume approximately 120W at idle. When measuring power at the wall, you might observe a higher power draw because the power supply converts AC current from the wall to DC current within the system, resulting in some expected loss.
+Blackhole® AI Processors typically consume approximately 120W at idle. When measuring power at the wall, you might observe a higher power draw because the power supply converts AC current from the wall to DC current within the system, resulting in some expected loss.
 
 Tenstorrent is exploring methods to further optimize idle power consumption through firmware updates and in future products.
 
-### **The temperatures reported by my Tenstorrent Blackhole™ card seem high**
+### **The temperatures reported by my Tenstorrent Blackhole® card seem high**
 
 The Blackhole AI Processor is designed to operate safely and continuously at temperatures up to 95°C, even if the ASIC temperature appears high. Existing cooling solutions maintain the Blackhole AI Processor chip, power circuitry, and memory ICs within safe operating specifications. The card automatically reduces clock speeds to prevent overheating.
 
 Tenstorrent is exploring methods to further optimize default operation through firmware updates and in future products.
 
 
-### **The fan noise of my Tenstorrent Blackhole™ p100a/p150a card is too quiet/too loud**
+### **The fan noise of my Tenstorrent Blackhole® p100a/p150a card is too quiet/too loud**
 
 Tenstorrent has received varied feedback regarding fan noise levels. Some users express concern about the noise level of their p100a or p150a models, while others prefer to tolerate increased noise to achieve lower idle and operating temperatures.
 
 Tenstorrent is evaluating the addition of end-user fan controls in a future update.
 
-### **What do I do if my Tenstorrent Blackhole™ card is not enumerating?**
+### **What do I do if my Tenstorrent Blackhole® card is not enumerating?**
 
-Blackhole™ PCIe cards are designed to operate using PCI Express Gen 5.0. However, Tenstorrent has observed instances where some motherboards set PCIe operation to *Auto* (often by default), which can prevent the card from enumerating. You can often resolve these issues by manually forcing PCIe operation to `Gen 4.0` or `Gen 5.0` in the **BIOS**.
+Blackhole® PCIe cards are designed to operate using PCI Express Gen 5.0. However, Tenstorrent has observed instances where some motherboards set PCIe operation to *Auto* (often by default), which can prevent the card from enumerating. You can often resolve these issues by manually forcing PCIe operation to `Gen 4.0` or `Gen 5.0` in the **BIOS**.
 
 :::{important}
 Once you successfully enter an operating environment where the card has enumerated, ensure that you update to the latest firmware. Refer to the [Installing the Tenstorrent Software Stack guide.](../../getting-started/README.md)
 :::
 
-### **How can I demonstrate the networking ability of my Tenstorrent Blackhole™ cards? How can I test multiple cards together?**
+### **How can I demonstrate the networking ability of my Tenstorrent Blackhole® cards? How can I test multiple cards together?**
 
-Setting up the Llama 3.1 8B model demo (instructions [here](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers)) is a useful way to test that your networked Blackhole™ cards are functioning as intended.
+Setting up the Llama 3.1 8B model demo (instructions [here](https://github.com/tenstorrent/tt-metal/tree/main/models/tt_transformers)) is a useful way to test that your networked Blackhole® cards are functioning as intended.
 
 ---
 

--- a/core/aibs/blackhole/p300.md
+++ b/core/aibs/blackhole/p300.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    product-name: Blackhole™ Tensix Processor, Blackhole™ p300c, Tenstorrent
+    product-name: Blackhole® Tensix Processor, Blackhole® p300c, Tenstorrent
     technology-concepts: PCIe, ATX, ESD, RISC-V, GDDR6, Floating point, Block floating point, Integer, TensorFloat, Vector
     document-type: Reference
 ---

--- a/core/getting-started/vLLM-servers.md
+++ b/core/getting-started/vLLM-servers.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    product-name: tt-inference-server, TT-QuietBox™, TT-LoudBox, Wormhole™ Networked AI Processor, Blackhole™ Networked AI Processor, n150s, n150d, n300s, n300d, p100a, p150a, p150b
+    product-name: tt-inference-server, TT-QuietBox®, TT-LoudBox, Wormhole™ Networked AI Processor, Blackhole® Networked AI Processor, n150s, n150d, n300s, n300d, p100a, p150a, p150b
     technology-concepts: LLM, vLLM, Hugging Face, Llama 3, deployment
     document-type: how-to
 ---
@@ -24,7 +24,7 @@ Before beginning this procedure, ensure that you have completed the base softwar
 
 ### **(Wormhole™ only)**
 
-:::{admonition} If you are using a TT-QuietBox™ or TT-LoudBox™ you must complete the following step
+:::{admonition} If you are using a TT-QuietBox® or TT-LoudBox™ you must complete the following step
 :class: warning
 
 For these systems you must configure a system-level mesh topology between the Wormhole™ Networked AI Processors. Run the following script to install `tt-topology` and configure the mesh.
@@ -63,7 +63,7 @@ The recommended large language models are gated and require a Hugging Face accou
 
 Visit the model's page on Hugging Face and follow the instructions to request access.
 
-* For TT-QuietBox™ and TT-LoudBox™ systems, we recommend [meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct)
+* For TT-QuietBox® and TT-LoudBox™ systems, we recommend [meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct)
 * For add-in-card products (n-series, p-series), we recommend [meta-llama/Llama-3.1-8B-Instruct](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct)
 
 For a full list of the currently available and tested models, please visit the [tt-inference-server GitHub page](https://github.com/tenstorrent/tt-inference-server).
@@ -205,8 +205,8 @@ Now that your model endpoint is running:
 * **Add a browser UI** — [TT-Studio](https://github.com/tenstorrent/tt-studio) wraps TT-Inference-Server with a point-and-click deployment and chat interface. Run `tt-studio` in the terminal to start it.
 * **Check supported models** — the [tt-inference-server repository](https://github.com/tenstorrent/tt-inference-server) is the authoritative source for which models are validated on each hardware generation.
 * **Use it as a coding assistant** — the [Coding Assistant with Aider](https://docs.tenstorrent.com/tt-vscode-toolkit/lessons/coding-assistant/) lesson walks through pairing a local vLLM endpoint with Aider for on-device pair programming.
-* **Build agents on top of it** — if you have a TT-QuietBox™ 2, the [Local AI Agents on QuietBox 2](https://docs.tenstorrent.com/tt-vscode-toolkit/lessons/qb2-local-agents/) lesson covers tool-calling pipelines and multi-agent workflows against your local endpoint.
-* **Try image and video generation** — if you have a TT-QuietBox™ 2, [TT-Local-Generator](https://docs.tenstorrent.com/tt-local-generator/) runs alongside inference with its own queue and gallery.
+* **Build agents on top of it** — if you have a TT-QuietBox® 2, the [Local AI Agents on QuietBox 2](https://docs.tenstorrent.com/tt-vscode-toolkit/lessons/qb2-local-agents/) lesson covers tool-calling pipelines and multi-agent workflows against your local endpoint.
+* **Try image and video generation** — if you have a TT-QuietBox® 2, [TT-Local-Generator](https://docs.tenstorrent.com/tt-local-generator/) runs alongside inference with its own queue and gallery.
 
 ---
 

--- a/core/systems/loudbox-bh/OS-setup.md
+++ b/core/systems/loudbox-bh/OS-setup.md
@@ -10,7 +10,7 @@ myst:
 
 *<span style="color: purple;">Note: This product is pre-launch and specifications are subject to change. This install guide would love your feedback! Please add it to the attached spreadsheet that came with this website package.</span>*
 
-This document provides first-time operating system and firmware setup for the Tenstorrent TT-LoudBox™ (Blackhole™) Air-Cooled 4U Server.
+This document provides first-time operating system and firmware setup for the Tenstorrent TT-LoudBox™ (Blackhole®) Air-Cooled 4U Server.
 
 :::{admonition} Important
 :class: important

--- a/core/systems/loudbox-bh/specifications.md
+++ b/core/systems/loudbox-bh/specifications.md
@@ -10,7 +10,7 @@ myst:
 
 *<span style="color: purple;">Note: This product is pre-launch and specifications are subject to change. This install guide would love your feedback! Please add it to the attached spreadsheet that came with this website package.</span>*
 
-This document provides detailed technical specifications for the Tenstorrent TT-LoudBox™ (Blackhole™) Air-Cooled 4U Server.
+This document provides detailed technical specifications for the Tenstorrent TT-LoudBox™ (Blackhole®) Air-Cooled 4U Server.
 
 For rack-mounting, setup, and cabling instructions, refer to the [Setup Guide](./setup.md).
 
@@ -34,11 +34,11 @@ Do not use the TT-LoudBox (Blackhole) in a way that it was not designed to be us
 | Memory | 768 GB (24x32 GB) DDR5 ECC RDIMM |
 | Expansion Slots | Nine PCIe 5.0 x16 FHFL slots |
 | Storage | 2 x 3.8 TB PCIe 4 NVMe |
-| Tensix Processors | 8x Tenstorrent Blackhole™ p150b Tensix Processors |
+| Tensix Processors | 8x Tenstorrent Blackhole® p150b Tensix Processors |
 | Power Cables Provided | 4x Quail Electronics IEC-60320-C13 to C14 F-M Universal Power Cords<br><div style="margin-left: 1.25em; margin-top: 0.35em;">Depending on your region, the following series will be provided with your Server<br>*Japan & Taiwan: Quail 1999.079<br>*Korea: TBD<br>*India: TBD<br>*Rest of the World: Quail 3532.110</div> |
 | Host System Connectivity Ports | 2x RJ45 10GbE LAN<br>1x RJ45 1GbE Dedicated BMC/IPMI<br>2x QSFP56 100GbE (NIC)<br>2x USB Type A<br>1x COM<br>1x VGA |
 | Other Cables | 10x QSFP-DD Passive 800G 0.5m for processor mesh (provided)<br>1x Mellanox 100G DAC for networking — optional (not provided)<br>1x Cat 6 for the BMC — optional (not provided)<br>1x RJ45 Standard Ethernet — optional (not provided) |
-| Tensix Processor Connectivity | 32x QSFP-DD Passive 800G (4x per Blackhole™ p150b card). Connects to other Blackhole Tensix Processors only. |
+| Tensix Processor Connectivity | 32x QSFP-DD Passive 800G (4x per Blackhole® p150b card). Connects to other Blackhole Tensix Processors only. |
 | Power Supply | 2+2 2000W Titanium Power Supply Units (PSUs). Expected peak consumption of 4kW. |
 | Base System | Supermicro GPU A+ Server AS-4125GS-TNRT |
 | Operating System | None installed; see instructions for installing Ubuntu 22.04 (Jammy Jellyfish) |

--- a/core/systems/quietbox/common/support.md
+++ b/core/systems/quietbox/common/support.md
@@ -7,7 +7,7 @@ myst:
 ---
 
 # Troubleshooting Common Hardware Issues
-This guide assists users in diagnosing and resolving common hardware issues with the TT-QuietBox™ system, including system instability, boot failures, and long-term maintenance tasks such as coolant refilling.
+This guide assists users in diagnosing and resolving common hardware issues with the TT-QuietBox® system, including system instability, boot failures, and long-term maintenance tasks such as coolant refilling.
 
 ## **Resolving System Instability or Random Reboots After a BIOS Change**
 
@@ -79,7 +79,7 @@ If the system still fails to boot and displays a `00 POST` code for an extended 
 **Cause:** Over time, a small amount of coolant may evaporate from the liquid cooling loop. This is normal for all liquid-cooled systems.
 
 :::{note}
-Your TT-QuietBox™ system ships with sufficient coolant for immediate and long-term operation. You do not need to add coolant to a new system. This procedure is only for maintenance after extended use.
+Your TT-QuietBox® system ships with sufficient coolant for immediate and long-term operation. You do not need to add coolant to a new system. This procedure is only for maintenance after extended use.
 :::
 
 **Solution:** Refill the coolant using the correct mixture.

--- a/core/systems/quietbox/quietbox-bh-2/compliance-qb2.md
+++ b/core/systems/quietbox/quietbox-bh-2/compliance-qb2.md
@@ -8,11 +8,11 @@ myst:
 
 # Regulatory Compliance Statements
 
-This document provides regulatory compliance information for the Tenstorrent TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) workstation (model TW-04003). It outlines the standards and regulations with which this device complies in various regions, assisting users in understanding compliance requirements for proper installation and operation.
+This document provides regulatory compliance information for the Tenstorrent TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) workstation (model TW-04003). It outlines the standards and regulations with which this device complies in various regions, assisting users in understanding compliance requirements for proper installation and operation.
 
 ## Compliance
 
-The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) complies with requirements of:
+The TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) complies with requirements of:
 
 \-       USA CFR Title 47, FCC Part 15, Subpart B, Class B
 
@@ -52,7 +52,7 @@ FCC Warning: The FCC requires that you be notified that any changes or modificat
 
 ### English
 
-The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) has been tested to comply with the Interference Causing Equipment Standard, ICES-003 Issue 7, CAN ICES-003(B)/NMB-003(B)
+The TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) has been tested to comply with the Interference Causing Equipment Standard, ICES-003 Issue 7, CAN ICES-003(B)/NMB-003(B)
 
 This device complies with Innovation, Science and Economic Development Canada (ISED) license-exempt RSS Standard(s). Operation is subject to the following two conditions: (1) this device may not cause interference, and (2) this device must accept any interference, including interference that may cause undesired operation of the device.
 
@@ -64,7 +64,7 @@ Le présent appareil est conforme aux CNR D’Innovation, Sciences et Développe
 
 ## United Kingdom
 
-The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) complies with the following UK Regulations.
+The TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) complies with the following UK Regulations.
 
 Electromagnetic Compatibility Regulations 2016 (S.I, 2016/1091)
 
@@ -74,7 +74,7 @@ Restrictions of the Use of Certain Hazardous Substances in Electrical and Electr
 
 ## Europe - CE Marking
 
-The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) bears the CE mark in compliance with the following EU Directives.
+The TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) bears the CE mark in compliance with the following EU Directives.
 
 EMC Directive 2014/30/EU
 

--- a/core/systems/quietbox/quietbox-bh-2/compliance-qb2.md
+++ b/core/systems/quietbox/quietbox-bh-2/compliance-qb2.md
@@ -1,0 +1,87 @@
+---
+myst:
+  html_meta:
+    product-name: TT-QuietBox 2, TW-04003, Blackhole
+    technology-concepts: Regulatory compliance, FCC, ISED, CE, RoHS, EMC Document
+    document-type: Reference
+---
+
+# Regulatory Compliance Statements
+
+This document provides regulatory compliance information for the Tenstorrent TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) workstation (model TW-04003). It outlines the standards and regulations with which this device complies in various regions, assisting users in understanding compliance requirements for proper installation and operation.
+
+## Compliance
+
+The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) complies with requirements of:
+
+\-       USA CFR Title 47, FCC Part 15, Subpart B, Class B
+
+\-       Innovation, Science and Economic Development Canada (ISED)
+
+\-       EUROPE - CE Marking
+
+\-       UK Electromagnetic Compatibility Regulations 2016 (S.I, 2016/1091)
+
+
+
+## United States of America
+
+This device complies with part 15 of the FCC Rules. Operation is subject to the following two conditions:
+
+\-       This device may not cause harmful interference.
+
+\-       This device must accept any interference received, including interference that may cause undesired operation.
+
+ This equipment has been tested and found to comply with the limits for a Class B digital device, pursuant to Part 15 of the FCC Rules. These limits are designed to provide reasonable protection against harmful interference in a residential installation. This equipment generates, uses, and can radiate radio frequency energy and, if not installed and used in accordance with the instructions, may cause harmful interference to radio communications. However, there is no guarantee that interference will not occur in a particular installation.
+
+If this equipment does cause harmful interference to radio or television reception, which can be determined by turning the equipment off and on, the user is encouraged to try to correct the interference by one or more of the following measures:
+
+\-       Reorient or relocate the receiving antenna.
+
+\-       Increase the separation between the equipment and receiver.
+
+\-       Connect the equipment into an outlet on a circuit different from that to which the receiver is connected.
+
+\-       Consult the dealer or an experienced radio/TV technician for help.
+
+FCC Warning: The FCC requires that you be notified that any changes or modifications to this device not expressly approved by the manufacturer could void the user’s authority to operate the equipment.
+
+
+
+## Canada
+
+### English
+
+The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) has been tested to comply with the Interference Causing Equipment Standard, ICES-003 Issue 7, CAN ICES-003(B)/NMB-003(B)
+
+This device complies with Innovation, Science and Economic Development Canada (ISED) license-exempt RSS Standard(s). Operation is subject to the following two conditions: (1) this device may not cause interference, and (2) this device must accept any interference, including interference that may cause undesired operation of the device.
+
+### Français
+
+Le présent appareil est conforme aux CNR D’Innovation, Sciences et Développement économique Canada applicables aux appareils radio exempts de licence. L’exploitation est autorisée aux deux conditions suivantes : (1) l’appareil ne doit pas produire de brouillage, et (2) l’utilisateur de l’appareil doit accepter tout brouillage radioélectrique subi, même si le brouillage est susceptible d’en compromettre le fonctionnement.
+
+
+
+## United Kingdom
+
+The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) complies with the following UK Regulations.
+
+Electromagnetic Compatibility Regulations 2016 (S.I, 2016/1091)
+
+Restrictions of the Use of Certain Hazardous Substances in Electrical and Electronic Equipment Regulations 2012 (S.I.2012/3032)
+
+
+
+## Europe - CE Marking
+
+The TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) bears the CE mark in compliance with the following EU Directives.
+
+EMC Directive 2014/30/EU
+
+RoHS, Directive 2011/65/EU
+
+
+
+## South Korea (한국)
+
+이 기기는 가정용(B급) 전자파적합기기로서 주로 가정에서 사용하는 것을 목적으로 하며, 모든 지역에서 사용할 수 있습니다.

--- a/core/systems/quietbox/quietbox-bh-2/index.rst
+++ b/core/systems/quietbox/quietbox-bh-2/index.rst
@@ -38,6 +38,7 @@ Reference Materials
    support-bh-2
    TT-QuietBox 2 Reference Guide <https://docs.tenstorrent.com/tt-quietbox2-guide/>
    Supported Models <https://tenstorrent.com/developers>
+   Compliance <compliance-qb2>
    
 
 

--- a/core/systems/quietbox/quietbox-bh-2/index.rst
+++ b/core/systems/quietbox/quietbox-bh-2/index.rst
@@ -30,7 +30,7 @@ Tutorials
 
 
 Reference Materials
----------------
+-------------------
 .. toctree::
    :maxdepth: 1
    

--- a/core/systems/quietbox/quietbox-bh-2/remote-access.md
+++ b/core/systems/quietbox/quietbox-bh-2/remote-access.md
@@ -1,14 +1,14 @@
 ---
 myst:
   html_meta:
-    product-name: TT-QuietBox Blackhole™, Blackhole™ Networked AI Processor
+    product-name: TT-QuietBox Blackhole®, Blackhole® Networked AI Processor
     technology-concepts: Remote Desktop Protocol (RDP), GNOME Remote Desktop, FreeRDP, headless access, macOS
     document-type: Task-Based Guide (How-To)
 ---
 
 # Remote Access to Your TT-QuietBox 2 from macOS
 
-Follow this guide to get headless remote desktop access to your TT-QuietBox<sup>™</sup> 2 from macOS.
+Follow this guide to get headless remote desktop access to your TT-QuietBox<sup>®</sup> 2 from macOS.
 
 ## One-Time TT-QuietBox 2 Setup
 

--- a/core/systems/quietbox/quietbox-bh-2/setup.md
+++ b/core/systems/quietbox/quietbox-bh-2/setup.md
@@ -60,15 +60,10 @@ myst:
 
 This guide shows users how to safely unbox, setup hardware, and install software on a TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) workstation.
 
-```{tip}
-For the complete handbook — system access & management, workloads & development, troubleshooting & recovery, and reference material beyond first setup — see the [**TT-QuietBox 2 Guide**](https://docs.tenstorrent.com/tt-quietbox2-guide/).
-```
-
 ## Before You Begin
 
-Choose a suitable location for your System:
-* Choose a stable area for the TT-QuietBox 2 where it will not need to be moved regularly. To ensure proper airflow intake, allow for 10 inches (25 cm) of clearance around the body of the workstation. Also avoid placing items on top of the workstation, as this can block the heat exhaust.
-* The Power Supply Unit (PSU) on the TT-QuietBox 2 is rated to draw up to 1600W of power and has demonstrated drawing 1200W of power running image generation models. A standard 15A circuit can handle up to 1800W. When choosing the location of your TT-QuietBox 2, be mindful of the other electronics which may draw power from the same circuit. We recommend putting the TT-QuietBox 2 on a dedicated circuit, if not you may trip a breaker.
+* Choose a stable area for the TT-QuietBox 2 where it will not need to be moved regularly. To ensure proper airflow intake, allow for 10 inches (25 cm) of clearance around the body of the workstation. Do not place items on top of the workstation, as this can block the heat exhaust.
+* The Power Supply Unit (PSU) on the TT-QuietBox 2 may draw up to 1300W of power while running high-load models like image generation. In 120V regions **(North America, South America, Japan, Taiwan)**, a standard residential 15A circuit supports a maximum continuous load of 1440W. If you are in one of these regions, avoid plugging the workstation into the same power circuit as other high-power devices. We recommend connecting the TT-QuietBox 2 to a dedicated circuit whenever possible. 
 * Review the {ref}`safety warnings <safety-warnings>`.
 * Inspect your package for signs of damage. Do not proceed with unboxing or installation if you suspect shipping damage to the system. Contact Tenstorrent support by [raising a support request.](https://tenstorrent.atlassian.net/servicedesk/customer/portal/1) Our team will review your request and provide assistance.
 
@@ -79,8 +74,8 @@ Ensure you have everything you need to get started.
 The Tenstorrent TT-QuietBox 2 (Blackhole) (TW-04003) package includes the following items:
 
 * 1x TT-QuietBox 2 (Blackhole) workstation
-* 1x Power Supply Cord (C19 to NEMA 5-15P)
-* 1x AnkerWork S500 speakerphone (included for some early customers to develop with text-to-speech (TTS) and speech-to-text (STT) AI models)
+* 1x Power Supply Cord (C19)
+* 1x eMeet Luna Plus speakerphone
 
 For setup, you will also need your own:
 * Keyboard
@@ -144,9 +139,9 @@ Note: Only use certified HDMI cables with the TT-QuietBox 2. Using non-certified
 
 1. **Connect the power cable.** Connect the provided C19 power cable to the workstation and then to a dedicated power outlet. See the Electrical Safety section for the full list of power requirements. 
 
-2. **Connect peripherals.** Connect the HDMI monitor, keyboard, and mouse to the back of the workstation. (Please note: video is not supported through the USB-C port). For internet connections, we recommend Ethernet over WiFi for faster downloading of models. If you prefer Ethernet, connect your Ethernet cable to the RJ45 port. 
+2. **Connect peripherals.** Connect the HDMI monitor, keyboard, and mouse to the back of the workstation. (Please note: video is not supported through the USB-C port). For internet connections, we recommend Ethernet over WiFi for faster downloading of models.
 
-3. **Power on the workstation.** On the back of the workstation, flip the switch on the PSU to the "I" position.  
+3. **Power on the workstation.** On the back of the workstation, flip the switch on the PSU to the "ON" position.  
 
 4. **On the front of the workstation, press the power button to turn the system on.**
 
@@ -183,23 +178,23 @@ Network bandwidth is significantly better over wired Ethernet than WiFi, which m
 
 ## Step 6. Update System Software
 
-TT-QuietBox 2 comes pre-installed with the Ubuntu operating system (24.04.3 LTS). 
+TT-QuietBox 2 comes pre-installed with the Ubuntu operating system (24.04).
 
-**Step 1:** Upon logging in, a Ubuntu Software Updater may offer a prompt that new software has been issued since the latest release. If this prompt appears, click "Install Now" to download the latest Ubuntu updates.
+**Step 1:** After logging in, Ubuntu Software Updater may prompt you to install updates. If prompted, select Install Now.
 
-**Step 2:** To ensure you have the latest system package updates, open a Terminal window by pressing Ctrl+Alt+T and run:
+**Step 2:** To update the Ubuntu system packages, open a Terminal window by pressing Ctrl+Alt+T and run:
 
 ```bash
 sudo apt update && sudo apt upgrade -y
 ```
 
-**Step 3:** Install the latest Tenstorrent firmware and system software, which will then trigger a system reboot:
+**Step 3:** Install the latest validated Tenstorrent firmware and system software. The installer selects the compatible, known-good software stack and automatically reboots the system:
 
 ```bash
-/bin/bash <(curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh) --mode-non-interactive
+/bin/bash <(curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh) --mode-non-interactive --use-uv
 ```
 
-Log in with `ttuser` and proceed to the next step.
+After the system reboots, log in with `ttuser` and continue to the next step.
 
 ---
 ## Step 7: Verify System Recognition of Blackhole Cards

--- a/core/systems/quietbox/quietbox-bh-2/setup.md
+++ b/core/systems/quietbox/quietbox-bh-2/setup.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    product-name: TT-QuietBox Blackhole™, Blackhole™ Networked AI Processor, Tensix core  
+    product-name: TT-QuietBox Blackhole®, Blackhole® Networked AI Processor, Tensix core  
     technology-concepts: PCIe, QSFP-DD, Installation, Setup, Electrostatic Discharge (ESD), Basic Input/Output System (BIOS)  
     document-type: Task-Based Guide (How-To)
 ---
@@ -58,7 +58,7 @@ myst:
 
 # Hardware and Software Setup
 
-This guide shows users how to safely unbox, setup hardware, and install software on a TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) workstation.
+This guide shows users how to safely unbox, setup hardware, and install software on a TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) workstation.
 
 ## Before You Begin
 

--- a/core/systems/quietbox/quietbox-bh-2/setup.md
+++ b/core/systems/quietbox/quietbox-bh-2/setup.md
@@ -180,15 +180,15 @@ Network bandwidth is significantly better over wired Ethernet than WiFi, which m
 
 TT-QuietBox 2 comes pre-installed with the Ubuntu operating system (24.04).
 
-**Step 1:** After logging in, Ubuntu Software Updater may prompt you to install updates. If prompted, select Install Now.
+**Step 1:** Upon logging in, a Ubuntu Software Updater may offer a prompt that new software has been issued since the latest release. If this prompt appears, click “Install Now” to download the latest Ubuntu updates.
 
-**Step 2:** To update the Ubuntu system packages, open a Terminal window by pressing Ctrl+Alt+T and run:
+**Step 2:** To ensure you have the latest system package updates, open a Terminal window by pressing Ctrl+Alt+T and run:
 
 ```bash
 sudo apt update && sudo apt upgrade -y
 ```
 
-**Step 3:** Install the latest validated Tenstorrent firmware and system software. The installer selects the compatible, known-good software stack and automatically reboots the system:
+**Step 3:** Install the latest Tenstorrent firmware and system software, which will then trigger a system reboot:
 
 ```bash
 /bin/bash <(curl -fsSL https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh) --mode-non-interactive --use-uv

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -12,7 +12,7 @@ myst:
 
 # Specifications
 
-This document provides detailed technical specifications for the TT-QuietBox<sup>™</sup> 2 (Blackhole<sup>®</sup>) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
+This document provides detailed technical specifications for the TT-QuietBox<sup>®</sup> 2 (Blackhole<sup>®</sup>) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
 
 ## **Package Contents**
 

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -76,7 +76,7 @@ For the most up-to-date list of models supported by TT-QuietBox 2, check the [De
 
 | Topic | Specification |
 | --- | --- |
-| Peak Power Consumption | 1500kW |
+| Peak Power Consumption | 1500W |
 | Operating Temperature | 50°F to 95°F (10°C to 35°C) |
 | Operating Relative Humidity | 10% to 90% (non-condensing) |
 | Non-Operating Temperature | -4°F to 140°F (-20°C to 60°C) |

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -136,7 +136,7 @@ The interior of the workstation can become extremely hot when running. Do not to
 Failure to follow these electrical safety instructions may result in electric shock, fire, or damage to the workstation.
 
 * Do not share the workstation's electrical outlet with other high-power devices. Do not use household surge strips, extension cords, or multi-outlet power taps.
-* Use only the provided C19 power cable provided, and ensure it is plugged into a properly grounded outlet. Do not bypass the grounding pin. Using a non-Tenstorrent approved power cable may result in equipment damage, electric shock, or fire hazard.
+* Use only the provided C19 power cable, and ensure it is plugged into a properly grounded outlet. Do not bypass the grounding pin. Using a non-Tenstorrent approved power cable may result in equipment damage, electric shock, or fire hazard.
 * If the circuit becomes overloaded and if the breaker trips, immediately disconnect and remove the power cord. Tenstorrent recommends a qualified electrician inspect and verify the circuit’s capacity before resuming setup.  
 * Never attempt to reset or bypass a tripped breaker without first confirming the circuit integrity; failure to do so may result in overheating, voltage drop, or irreversible damage.
 :::

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -20,7 +20,7 @@ The Tenstorrent TT-QuietBox 2 (Blackhole) system package includes the following 
 
 * 1x TT-QuietBox 2 (Blackhole) workstation
 * 1x Power Supply Cord (C19 to country-specific wall outlet)
-* 1x eMeet Luna Plus
+* 1x eMeet Luna Plus speakerphone
 
 ## **TT-QuietBox 2 System Specifications**
 
@@ -124,6 +124,11 @@ This is especially relevant to users in 120V countries, such as the USA, Canada,
 
 (safety-warnings)=
 ## **Important Safety Warnings**
+
+:::{admonition} Caution: Hot Surface
+:class: caution
+The interior of the workstation can become extremely hot when running. Do not touch any interior components of the workstation without turning the power off, letting the PSU fully drain, and allowing interior components to cool.
+:::
 
 ### **Electrical Safety** 
 

--- a/core/systems/quietbox/quietbox-bh-2/specifications.md
+++ b/core/systems/quietbox/quietbox-bh-2/specifications.md
@@ -19,23 +19,25 @@ This document provides detailed technical specifications for the TT-QuietBox<sup
 The Tenstorrent TT-QuietBox 2 (Blackhole) system package includes the following items:
 
 * 1x TT-QuietBox 2 (Blackhole) workstation
-* 1x Power Supply Cord (C19 to NEMA 5-15P)
-* 1x AnkerWork S500 Speakerphone
+* 1x Power Supply Cord (C19 to country-specific wall outlet)
+* 1x eMeet Luna Plus
 
 ## **TT-QuietBox 2 System Specifications**
 
 | Specification | Details |
 | ----- | ----- |
 | Model | TW-04003 |
-| Operating System | Ubuntu 24.04.3 LTS |
+| Operating System | Ubuntu 24.04 |
 | CPU | Ryzen 7 9700X 65W Granite Ridge 3.8GHz |
 | Motherboard | ASRock B850M-C, mATX |
 | Memory | 256 GB (4x64 GB) DDR5-5600 UDIMM, CL46 (4 slots, 0 free) |
-| Storage | 4TB (WDS400T4B0E-00BKY0)<br /> 1x Blazing M.2 (PCIe Gen5x4) with WD Blue SN5000 NVMe SSD<br /> 1x Hyper M.2 (PCIe Gen4x4)<br /> 1x M.2 (PCIe Gen3x2 & SATA3) |
+| Storage | 4TB - WD Blue SN5000 NVMe™ SSD<br />Hyper M.2 (PCIe Gen4x4)<br />WDS400T4B0E-00BKY0 |
 | Tenstorrent Processors | 2x Blackhole p300c cards (4 Blackhole chips) |
-| External I/O Ports | 1x HDMI Port<br />1x USB 3.2 Gen 2 Type-A Port<br />1x USB 3.2 Gen 2 Type-C Port (non-video)<br />2x USB 3.2 Gen 1 Ports<br />4x USB 2.0 Ports<br />1 x BIOS Flashback Button<br />HD Audio Jacks: Line in / Front Speaker / Microphone |
-| Connectivity | 1 x RJ45 LAN Port<br /><ul class="tt-spec-cell-list"><li>Gigabit LAN 10/100/1000 Mb/s Base T</li><li>Realtek 8111H</li></ul><br />2x WiFi Antenna<br /><ul class="tt-spec-cell-list"><li>802.11ax WiFi 6 Module</li><li>Supports IEEE 802.11a/b/g/n/ax</li><li>Supports Dual-Band (2.4/5 GHz)</li><li>Supports Bluetooth 5.3</li></ul> |
+| Rear I/O Panel | 1x HDMI Port<br />1x USB 3.2 Gen 2 Type-A Port<br />1x USB 3.2 Gen 2 Type-C Port (non-video)<br />2x USB 3.2 Gen 1 Ports<br />4x USB 2.0 Ports<br />1 x BIOS Flashback Button<br />HD Audio Jacks: Line in / Front Speaker / Microphone |
+| Network Controller | Gigabit LAN 10/100/1000 Mb/s Base T<br />Realtek 8111H |
+| Wireless LAN | 802.11ax WiFi 6 Module<br />Supports IEEE 802.11a/b/g/n/ax<br />Supports Dual-Band (2.4/5 GHz)<br />Supports Bluetooth 5.3 |
 | Power Supply | 1600W Cooler Master V Platinum 1600 V2 |
+| Idle Power | 750W |
 | Sound Pressure | 38 dBA (under max operating load) |
 | System Dimensions | Height: 15.6” (39.5 cm) Width: 9.1” (23.1 cm) Depth: 17.8” (45.2 cm) (including handles and feet) |
 | System Weight | 20 kg (44 lbs) +/- 1.5 lbs   |
@@ -44,21 +46,20 @@ The Tenstorrent TT-QuietBox 2 (Blackhole) system package includes the following 
 
 ## **Blackhole p300 Card Specifications**
 
-TT-QuietBox 2 is powered by two p300c cards for a total of four Blackhole chips. The table below describes the specifications of a single p300c card for your reference. Please note the p300c card is not sold separately outside of the QuietBox 2. If you are interested in a Blackhole card to add to your existing system, check out our [available cards](https://www.tenstorrent.com/cards).
+The TT-QuietBox 2 is powered by two p300c cards, for a total of four Blackhole chips. The table below describes the combined specifications of the two cards for your reference. Please note the p300c card is not sold separately outside of the TT-QuietBox 2. If you are interested in a Blackhole card to add to your existing system, check out our [available cards](https://www.tenstorrent.com/cards).
 
-| Specification             | Single p300c card                    | QuietBox 2 (two cards)                             |
-| ------------------------- | ------------------------------------ | -------------------------------------------------- |
-| Part Number               | TC-03007                             | 2x TC-03007                                        |
-| Tensix Cores              | 240                                  | 480                                                |
-| AI Clock                  | 1.35 GHz                             | 1.35 GHz                                           |
-| SRAM                      | 360 MB (1.5 MB per Tensix core)      | 720 MB (1.5 MB per Tensix core)                    |
-| Memory                    | 64GB GDDR6                           | 128GB GDDR6                                        |
-| Memory Speed              | 16 GT/sec                            | 16 GT/sec                                          |
-| Memory Bandwidth          | 1024 GB/sec                          |  -                                        |
-| TBP (Total Board Power)   | 600W                                 | -                                                  |
-| Cooling                   | Liquid                               | Liquid                                             |
-| Connectivity              |  2x Warp400 (internally connected, diagrams below.)                                   |  - |
-| Dimensions (WxDxH)        | 21.66mm x 307mm x 112.65mm           | -                                                  |
+| Specification             | Two p300c Cards (inside TT-QuietBox 2)                             |
+| ------------------------- | -------------------------------------------------- |
+| Part Number               | 2x TC-03007                                        |
+| Tensix Cores              | 240 + 240                                              |
+| AI Clock                  | 1.35 GHz                                           |
+| SRAM                      | 360 + 360 MB (1.5 MB per Tensix core)                   |
+| Memory                    | 128GB GDDR6                                      |
+| Memory Speed              | 16 GT/sec                                          |
+| Memory Bandwidth          |  1024 GB/sec chip to chip                                    |
+| TBP (Total Board Power)   | 600W + 600W                                                 |
+| Cooling                   | Liquid                                             |
+| Dimensions (WxDxH)        | 21.66mm x 307mm x 112.65mm (each card)   |
 
 ## **Internal Topology**
 
@@ -75,13 +76,15 @@ For the most up-to-date list of models supported by TT-QuietBox 2, check the [De
 
 | Topic | Specification |
 | --- | --- |
-| Peak Power Consumption | 1.5kW |
+| Peak Power Consumption | 1500kW |
 | Operating Temperature | 50°F to 95°F (10°C to 35°C) |
 | Operating Relative Humidity | 10% to 90% (non-condensing) |
 | Non-Operating Temperature | -4°F to 140°F (-20°C to 60°C) |
 | Non-Operating Relative Humidity |  5% to 95% (non-condensing) |
 
-The Power Supply Unit (PSU) on the TT-QuietBox 2 is rated to draw up to 1600W of power and has demonstrated drawing 1200W of power running image generation models. A standard 15A circuit can handle up to 1800W. When choosing the location of your TT-QuietBox 2, be mindful of the other electronics which may draw power from the same circuit. We recommend putting the TT-QuietBox 2 on a dedicated circuit, if not you may trip a breaker.
+The TT-QuietBox 2 draws up to 1,300W at peak load. To prevent overloading the power circuit or tripping your electrical panel, avoid sharing the circuit with other high-power devices, or connect it to a dedicated circuit.
+This is especially relevant to users in 120V countries, such as the USA, Canada, and Japan.
+
 
 ## **System Overview**
 
@@ -92,9 +95,12 @@ The Power Supply Unit (PSU) on the TT-QuietBox 2 is rated to draw up to 1600W of
 | No | Item | Description |
 | --- | --- | --- |
 | 1 | Handle | Used to aid in lifting the workstation |
-| 2 | Glass Panel | Showcases internal Accelerator cards |
-| 3 | Thumbscrew | Enables toolless access to the interior |
-| 4 | Power and Reset Buttons | Powers the workstation on/off and resets the workstation |
+| 2 | Acrylic Panel | Showcases internal Accelerator cards |
+| 3 | Thumbscrew | Enables toolless access to the interior* |
+| 4 | Power Button | Powers the workstation on/off |
+| 5 | Reset Button | Resets the workstation |
+
+*This workstation is designed for adult use only. Ensure the TT-QuietBox 2 is located where children cannot access or tamper with it. Keep the workstation secure when not in use.
 
 ## **System Rear View**
 
@@ -112,7 +118,7 @@ The Power Supply Unit (PSU) on the TT-QuietBox 2 is rated to draw up to 1600W of
 | 6 | On/Off Power Supply Unit Switch |
 | 7 | 1x USB 3.2 Gen 2 Type-C Port (non-video) |
 | 8 | 2x USB 3.2 Gen 1 Type-A Ports |
-| 9 | 1x RJ45 **TBD GbE** LAN Port |
+| 9 | 1x RJ45 Gigabit LAN Port (10/100/1000 Mbps, Realtek 8111H) |
 | 10 | 2x WiFi Antenna |
 | 11 | HD Audio Jacks: Line in / Front Speaker / Microphone  |
 
@@ -124,10 +130,9 @@ The Power Supply Unit (PSU) on the TT-QuietBox 2 is rated to draw up to 1600W of
 :::{danger}
 Failure to follow these electrical safety instructions may result in electric shock, fire, or damage to the workstation.
 
-* Ensure you are connecting the power to an AC power circuit with sufficient capacity to support 15A. Failure to connect to dedicated 15A breaker may result in tripping the breaker, or dangerous operating conditions.
-* Do not share the outlet with other high-power devices. Avoid using household surge strips, extension cords, or multi-outlet power taps; not all are rated for the sustained current of this system.  
-* Use only the provided C19 power cable, and ensure it is plugged into a properly grounded outlet. Do not bypass or disable the grounding pin.  Using a non-Tenstorrent approved power cable may result in dangerous operating conditions.
-* If the circuit becomes overloaded or if the breaker trips during power-up or operation, immediately disconnect and remove power. Then, have a qualified electrician inspect and verify the circuit’s capacity before resuming setup.  
+* Do not share the workstation's electrical outlet with other high-power devices. Do not use household surge strips, extension cords, or multi-outlet power taps.
+* Use only the provided C19 power cable provided, and ensure it is plugged into a properly grounded outlet. Do not bypass the grounding pin. Using a non-Tenstorrent approved power cable may result in equipment damage, electric shock, or fire hazard.
+* If the circuit becomes overloaded and if the breaker trips, immediately disconnect and remove the power cord. Tenstorrent recommends a qualified electrician inspect and verify the circuit’s capacity before resuming setup.  
 * Never attempt to reset or bypass a tripped breaker without first confirming the circuit integrity; failure to do so may result in overheating, voltage drop, or irreversible damage.
 :::
 
@@ -135,8 +140,8 @@ Failure to follow these electrical safety instructions may result in electric sh
 
 :::{admonition} Important
 :class: warning
-Before opening the TT-QuietBox 2 Blackhole workstation or handling any internal components, you must discharge static electricity from your body to avoid damaging sensitive hardware. Electrostatic discharge can permanently damage Tensix cores, memory modules, or other components. Handle with care and always follow ESD-safe practices.
-* Touch a grounded metal surface, such as a grounded rack, chassis, or power supply casing, before and during internal handling.  
+Electrostatic discharge (ESD) can permanently damage Tensix cores, memory modules, or other components. Handle with care and always follow ESD-safe practices. Before opening the TT-QuietBox 2  workstation or handling the internal components, you must discharge static electricity to avoid damaging ESD sensitive hardware. 
+* Touch an exposed metal surface, such as a grounded rack, chassis, or power supply casing, before and during internal handling.  
 * Ideally, wear an ESD wrist strap connected to a verified ground point.  
 * Avoid working on carpeted floors or in low-humidity environments where static buildup is more likely.  
 * Do not touch any processor, memory module, connector, or printed circuit board (PCB) circuitry unless absolutely necessary, and only after properly discharging.
@@ -146,5 +151,5 @@ Before opening the TT-QuietBox 2 Blackhole workstation or handling any internal 
 
 * This equipment has been tested and found to comply with the limits for a Class B digital device, pursuant to part 15 of the FCC Rules. These limits are designed to provide reasonable protection against harmful interference in a residential installation.
 * This equipment generates, uses and can radiate radio frequency energy and, if not installed and used in accordance with the instructions, may cause harmful interference to radio communications. However, there is no guarantee that interference will not occur in a particular installation.
-* Changes or modifications to this workstation which are not expressly approved by Tenstorrent may void the user's authority to operate it. Tenstorrent cannot accept responsibility for any failure to satisfy any Safety, EMC or regulatory requirements that result from non-approved modification of the product, including the fitting of non-Tenstorrent cards, cables, or any other hardware or software modification which may affect compliance. To avoid damage and personal injury, only use Tenstorrent approved hardware with this device. 
+* Changes or modifications to this workstation which are not expressly approved by Tenstorrent may void the user's authority to operate it. Tenstorrent cannot accept responsibility for any failure to satisfy any Safety, EMC or regulatory requirements that result from non-approved modification of the product, including the fitting of non-Tenstorrent cards, cables, or any other hardware or software modification which may affect compliance. To avoid damage and personal injury, only use Tenstorrent approved components with this device. 
 * Do not use the TT-QuietBox 2 in a way that it was not designed to be used.

--- a/core/systems/quietbox/quietbox-bh-2/support-bh-2.md
+++ b/core/systems/quietbox/quietbox-bh-2/support-bh-2.md
@@ -24,13 +24,13 @@ TT-QuietBox 2 is designed to operate in a typical office, lab, or home-office en
 For detailed information on power draw and circuit breaker requirements, see the [Specifications page of the TT-QuietBox 2 documentation](./specifications.md).
 
 ### Does My TT-QuietBox 2 Require Maintenance?
-Yes. Like any liquid-cooled desktop workstation, TT-QuietBox 2 will require periodic coolant top-ups. Under typical development workloads, you can expect to do this approximately every year. Exact intervals depend on usage, environment, and duty cycle.
+Yes. Like any liquid-cooled desktop workstation, TT-QuietBox 2 will require periodic coolant top-ups. Under typical development workloads, you can expect to do this approximately every year. 
 
-Maintenance procedures and recommended coolant/service guidelines will be documented in the TT-QuietBox 2 hardware documentation.
+Maintenance procedures and recommended coolant/service guidelines will be documented in the TT-QuietBox 2 Field Replacable Unit (FRU) documentation
 
 ### How Loud Is the TT-QuietBox 2?
 
-TT-QuietBox 2 is liquid-cooled and engineered to run quietly enough for office or home-office use. Actual noise levels depend on workload and ambient conditions, but the system is intended to be comfortable to use at a desk compared to traditional air-cooled workstations. Our lab tests measured 39.8 dBA sound pressure under maximum operating load (for reference, a typical front-load washing machine operates between 40-50 dBA).
+TT-QuietBox 2 is liquid-cooled and engineered to run quietly enough for office or home-office use. Actual noise levels depend on workload and ambient conditions, but the system is intended to be comfortable to use at a desk compared to traditional air-cooled workstations. Our lab tests measured less than 40 dBA sound pressure under maximum operating load.
 
 ### What Kind of Power Outlet Do I Need? How Much Power Does It Draw?
 

--- a/core/systems/quietbox/quietbox-bh-2/welcome.md
+++ b/core/systems/quietbox/quietbox-bh-2/welcome.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    product-name: TT-QuietBox Blackhole™, Blackhole™ AI Processor, Tensix core
+    product-name: TT-QuietBox Blackhole®, Blackhole® AI Processor, Tensix core
     technology-concepts: local AI, inference, agent frameworks, video generation, Tensix architecture, RISC-V, tt-toplike, tt-local-generator, tt-vscode-toolkit
     document-type: Conceptual Guide (What's Next)
 ---

--- a/core/systems/quietbox/quietbox-bh/index.md
+++ b/core/systems/quietbox/quietbox-bh/index.md
@@ -1,24 +1,24 @@
 ---
 myst:
   html_meta:
-    product-name: TT-QuietBox Blackhole™, Blackhole™ Networked AI Processor, Tensix core
+    product-name: TT-QuietBox Blackhole®, Blackhole® Networked AI Processor, Tensix core
     technology-concepts: PCIe, QSFP-DD, Installation, Setup, Specifications, Electrostatic Discharge (ESD), Basic Input/Output System (BIOS)
     document-type: Product Guide
 ---
 
 # TT-QuietBox (Blackhole)
 
-This page covers everything for the TT-QuietBox Blackhole™ workstation: how to
+This page covers everything for the TT-QuietBox Blackhole® workstation: how to
 receive and set it up, and its full hardware specifications. Use the page
 navigation on the right to jump between sections.
 
 ## Receiving, Unboxing, and Setup
 
-This guide provides system administrators, hardware engineers, and users responsible for the initial setup of Tenstorrent hardware with step-by-step instructions. You will learn to safely unbox a TT-QuietBox Blackhole™ workstation, connect all required hardware components, and install the recommended operating system.
+This guide provides system administrators, hardware engineers, and users responsible for the initial setup of Tenstorrent hardware with step-by-step instructions. You will learn to safely unbox a TT-QuietBox Blackhole® workstation, connect all required hardware components, and install the recommended operating system.
 
 ### **Before You Begin**
 
-Before you begin, choose a clear, stable, and spacious area for the TT-QuietBox Blackhole™ workstation. The system ships in a palletized wooden crate. Ensure you have at least two people and enough room for them to maneuver comfortably and safely around the crate and system. Clear the area where you intend to use the TT-QuietBox Blackhole™ and ensure to use a dedicated 20A circuit and outlet, as specified in the [electrical safety warning](#safety-warnings) below. Also, confirm that all vents are clear of obstructions or other objects.
+Before you begin, choose a clear, stable, and spacious area for the TT-QuietBox Blackhole® workstation. The system ships in a palletized wooden crate. Ensure you have at least two people and enough room for them to maneuver comfortably and safely around the crate and system. Clear the area where you intend to use the TT-QuietBox Blackhole® and ensure to use a dedicated 20A circuit and outlet, as specified in the [electrical safety warning](#safety-warnings) below. Also, confirm that all vents are clear of obstructions or other objects.
 
 :::{warning}
 The fully palletized and crated shipment weighs approximately 134 lbs (61 kg), and the workstation itself weighs approximately 80 lbs (36 kg). Unboxing and lifting require at least two people for safe maneuverability.
@@ -42,7 +42,7 @@ For setup, you will need the following:
 
 ### **Step 1: Unboxing the Workstation**
 
-Follow these steps to unbox your TT-QuietBox Blackhole™ workstation:
+Follow these steps to unbox your TT-QuietBox Blackhole® workstation:
 
 1. **Position the crate.** Position the crate in your prepared unboxing area, ensuring ample space for two people to work around it.  
 
@@ -69,11 +69,11 @@ Follow these steps to unbox your TT-QuietBox Blackhole™ workstation:
 
 ![](qb_setup_6.jpg)
 
-7. **Remove the workstation from the cardboard box.** Reach into the short sides of the box, secure your hands under the supportive styrofoam, and lift the TT-QuietBox Blackhole™ workstation out of the box. Place it in your workspace.  
+7. **Remove the workstation from the cardboard box.** Reach into the short sides of the box, secure your hands under the supportive styrofoam, and lift the TT-QuietBox Blackhole® workstation out of the box. Place it in your workspace.  
 
 ![](qb_setup_7.jpg)
 
-8. **Remove additional packing material.** Remove any remaining packaging from the exterior of the TT-QuietBox Blackhole™ workstation.  
+8. **Remove additional packing material.** Remove any remaining packaging from the exterior of the TT-QuietBox Blackhole® workstation.  
 
 ![](qb_setup_8.jpg)
 
@@ -83,13 +83,13 @@ Follow these steps to unbox your TT-QuietBox Blackhole™ workstation:
 
 ### **Step 2: Setting Up the Hardware**
 
-Follow these steps to set up the hardware for your TT-QuietBox Blackhole™ workstation:
+Follow these steps to set up the hardware for your TT-QuietBox Blackhole® workstation:
 
 1. **Connect the power cable.** Connect the provided C13 power cable to the workstation and then to a dedicated power outlet.  
 
 ![](qb_setup_power.jpg)
 
-2. **Connect QSFP-DD cables.** The included Quad Small Form-factor Pluggable Double Density (QSFP-DD) cables enable high-speed interconnectivity between the Tenstorrent Tensix cores. Your system includes four Blackhole™ processors and eight external QSFP-DD cables to create the processor mesh. Connect the eight cables according to the system topology diagram below. Ensure each cable is aligned correctly and clicks into place; do not force the connections.  
+2. **Connect QSFP-DD cables.** The included Quad Small Form-factor Pluggable Double Density (QSFP-DD) cables enable high-speed interconnectivity between the Tenstorrent Tensix cores. Your system includes four Blackhole® processors and eight external QSFP-DD cables to create the processor mesh. Connect the eight cables according to the system topology diagram below. Ensure each cable is aligned correctly and clicks into place; do not force the connections.  
 
 ![](qb_bh_topology.png)
 
@@ -168,7 +168,7 @@ If you encounter any issues, or have a question that isn't covered in the docume
 
 ## Specifications and Requirements
 
-This section provides system administrators and engineers with detailed technical specifications for the TT-QuietBox™ Blackhole™ (TW-04002) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
+This section provides system administrators and engineers with detailed technical specifications for the TT-QuietBox® Blackhole® (TW-04002) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
 
 ### **Package Contents**
 
@@ -193,7 +193,7 @@ For assembly instructions, refer to the [Receiving, Unboxing, and Setup](#receiv
 | Motherboard | ASRock Rack [SIENAD8-2L2T](https://www.asrockrack.com/general/productdetail.asp?Model=SIENAD8-2L2T#Specifications)* |
 | Memory | 512 GB (8x64 GB) DDR5-4800 ECC RDIMM (0 Slots Free) |
 | Storage | 4 TB NVMe PCIe 4.0 x4 |
-| Tenstorrent Processors | 4x Tenstorrent Blackhole™ p150c Tensix Processor |
+| Tenstorrent Processors | 4x Tenstorrent Blackhole® p150c Tensix Processor |
 | Included Cables | 8x QSFP-DD 800GbE Cable |
 | Host Connectivity | 2x RJ45 10GBase-T via Intel® X710<br />2x RJ45 1GBase-T via Intel® I210<br />4x USB 3.1 Gen 1 (5 Gbps) Type-A (2x Front, 2x Rear)<br />1x VGA<br />1x IPMI | 2x RJ45 10GBase-T via Intel® X710<br />2x RJ45 1GBase-T via Intel® I210<br />4x USB 3.1 Gen 1 (5 Gbps) Type-A (2x Front, 2x Rear)<br />1x VGA<br />1x IPMI |
 | Tensix Processor Connectivity | 16x QSFP-DD Passive 800G (4 ports per card) |
@@ -218,7 +218,7 @@ The TT-QuietBox Liquid-Cooled Desktop Workstation is designed to operate at up t
 Failure to follow these electrical safety instructions may result in electric shock, fire, or damage to the equipment.
 :::
 
-* Connect the system to a dedicated AC power circuit with sufficient capacity to support the full power draw of the TT-QuietBox Blackhole™ workstation, including peak loads under heavy AI model execution.  
+* Connect the system to a dedicated AC power circuit with sufficient capacity to support the full power draw of the TT-QuietBox Blackhole® workstation, including peak loads under heavy AI model execution.  
 * Do not share the outlet with other high-power devices. Avoid using household surge strips, extension cords, or multi-outlet power taps; not all are rated for the sustained current of this system.  
 * Use only the provided C13 power cable, and ensure it is plugged into a properly grounded outlet. Do not bypass or disable the grounding pin.  
 * Verify that the circuit wiring and breaker rating meet or exceed the combined system requirements, including liquid-cooling support and all accelerator cards.  
@@ -229,7 +229,7 @@ Failure to follow these electrical safety instructions may result in electric sh
 
 :::{admonition} Important
 :class: warning
-Before opening the TT-QuietBox Blackhole™ workstation or handling any internal components, you must discharge static electricity from your body to avoid damaging sensitive hardware. Electrostatic discharge can permanently damage Tensix cores, memory modules, or other components. Handle with care and always follow ESD-safe practices.
+Before opening the TT-QuietBox Blackhole® workstation or handling any internal components, you must discharge static electricity from your body to avoid damaging sensitive hardware. Electrostatic discharge can permanently damage Tensix cores, memory modules, or other components. Handle with care and always follow ESD-safe practices.
 * Touch a grounded metal surface, such as a grounded rack, chassis, or power supply casing, before and during internal handling.  
 * Ideally, wear an ESD wrist strap connected to a verified ground point.  
 * Avoid working on carpeted floors or in low-humidity environments where static buildup is more likely.  

--- a/core/systems/quietbox/quietbox-wh/index.md
+++ b/core/systems/quietbox/quietbox-wh/index.md
@@ -191,7 +191,7 @@ If you encounter any issues, or have a question that isn't covered in the docume
 
 ## Specifications and Requirements
 
-This document provides system administrators and engineers with detailed technical specifications for the TT-QuietBox™ Wormhole™ (TW-04001) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
+This document provides system administrators and engineers with detailed technical specifications for the TT-QuietBox® Wormhole™ (TW-04001) workstation. It lists package contents, hardware components, physical dimensions, and operating requirements.
 
 ### **Package Contents**
 
@@ -242,7 +242,7 @@ The TT-QuietBox Liquid-Cooled Desktop Workstation is designed to operate at up t
 Failure to follow these electrical safety instructions may result in electric shock, fire, or damage to the equipment.
 :::
 
-* Connect the system to a dedicated AC power circuit with sufficient capacity to support the full power draw of the TT-QuietBox Blackhole™ workstation, including peak loads under heavy AI model execution.  
+* Connect the system to a dedicated AC power circuit with sufficient capacity to support the full power draw of the TT-QuietBox Blackhole® workstation, including peak loads under heavy AI model execution.  
 * Do not share the outlet with other high-power devices. Avoid using household surge strips, extension cords, or multi-outlet power taps; not all are rated for the sustained current of this system.  
 * Use only the provided C13 power cable, and ensure it is plugged into a properly grounded outlet. Do not bypass or disable the grounding pin.  
 * Verify that the circuit wiring and breaker rating meet or exceed the combined system requirements, including liquid-cooling support and all accelerator cards.  
@@ -253,7 +253,7 @@ Failure to follow these electrical safety instructions may result in electric sh
 
 :::{admonition} Important
 :class: warning
-Before opening the TT-QuietBox Blackhole™ workstation or handling any internal components, you must discharge static electricity from your body to avoid damaging sensitive hardware. Electrostatic discharge can permanently damage Tensix cores, memory modules, or other components. Handle with care and always follow ESD-safe practices.
+Before opening the TT-QuietBox Blackhole® workstation or handling any internal components, you must discharge static electricity from your body to avoid damaging sensitive hardware. Electrostatic discharge can permanently damage Tensix cores, memory modules, or other components. Handle with care and always follow ESD-safe practices.
 * Touch a grounded metal surface, such as a grounded rack, chassis, or power supply casing, before and during internal handling.  
 * Ideally, wear an ESD wrist strap connected to a verified ground point.  
 * Avoid working on carpeted floors or in low-humidity environments where static buildup is more likely.  

--- a/core/tools/index.rst
+++ b/core/tools/index.rst
@@ -43,7 +43,7 @@ System Configuration
 
    * - `TT-Topology <https://github.com/tenstorrent/tt-topology>`_
 
-       TT-Topology is a command-line utility for configuring Ethernet routing on multi-card systems. Required on TT-QuietBox™ and TT-LoudBox™ Wormhole-based systems before running networked inference.
+       TT-Topology is a command-line utility for configuring Ethernet routing on multi-card systems. Required on TT-QuietBox® and TT-LoudBox™ Wormhole-based systems before running networked inference.
      -
 
 Analysis & Visualization

--- a/shared/_templates/layout.html
+++ b/shared/_templates/layout.html
@@ -61,7 +61,7 @@
         <a href="{{ _home }}#hardware">Hardware</a>
         <div class="tt-nav-dropdown">
           <span class="tt-nav-dropdown-label">Blackhole</span>
-          <a href="{{ _home }}aibs/blackhole/index.html">Blackhole™ PCIe Cards</a>
+          <a href="{{ _home }}aibs/blackhole/index.html">Blackhole® PCIe Cards</a>
           <a href="{{ _home }}systems/quietbox/quietbox-bh/index.html">TT-QuietBox</a>
           <a href="{{ _home }}systems/quietbox/quietbox-bh-2/index.html">TT-QuietBox 2</a>
           <a href="{{ _home }}systems/galaxy-blackhole/index.html">Galaxy™ (Blackhole)</a>


### PR DESCRIPTION
This updates various statements and values on the QB2 specs + hardware setup pages. It also creates a new Compliance page and fixes usage of registered trademark usage for Blackhole and QuietBox 2 across the repo.
The QB2 specs and hardware page updates were the result of a thorough audit from Kaitlyn, Bruce, Dan and Adam. This integrates their feedback.
There are a few more changes likely coming, but we will do those in a new PR since some things are still being debated, and this was already getting quite big. This covers 90% of what we needed to update.